### PR TITLE
feat: fd-commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,10 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
+name = "bytemuck"
+version = "1.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
+
+[[package]]
 name = "pldm-lib"
 version = "0.1.0"
 dependencies = [
  "bitfield",
+ "bytemuck",
  "zerocopy",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d7e60934ceec538daadb9d8432424ed043a904d8e0243f3c6446bce549a46ac"
 
 [[package]]
-name = "bytemuck"
-version = "1.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fbdf580320f38b612e485521afda1ee26d10cc9884efaaa750d383e13e3c5f4"
-
-[[package]]
 name = "pldm-lib"
 version = "0.1.0"
 dependencies = [
  "bitfield",
- "bytemuck",
  "zerocopy",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,5 @@ authors = ["Caliptra contributors", "OpenPRoT contributors"]
 edition = "2024"
 
 [dependencies]
-zerocopy = {version = "0.8.17", features = ["derive"]}
+zerocopy = { version = "0.8.17", features = ["derive"] }
 bitfield = "0.14.0"
-bytemuck = "1.24.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2024"
 [dependencies]
 zerocopy = {version = "0.8.17", features = ["derive"]}
 bitfield = "0.14.0"
+bytemuck = "1.24.0"

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -6,6 +6,7 @@ use zerocopy::{FromBytes, Immutable, IntoBytes};
 pub enum PldmCodecError {
     BufferTooShort,
     Unsupported,
+    InvalidData,
 }
 
 /// A trait for encoding and decoding PLDM (Platform Level Data Model) messages.
@@ -67,6 +68,9 @@ pub trait PldmCodecWithLifetime<'a>: core::fmt::Debug + Sized {
 }
 
 // Default implementation of PldmCodec for types that can leverage zerocopy.
+// TODO: can we generalize this to use sub-struct encodes when possible?
+// There are structs like PldmFirmwareString that contain variable-length data
+// that would need special handling.
 impl<T> PldmCodec for T
 where
     T: core::fmt::Debug + Sized + FromBytes + IntoBytes + Immutable,

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -37,6 +37,35 @@ pub trait PldmCodec: core::fmt::Debug + Sized {
     fn decode(buffer: &[u8]) -> Result<Self, PldmCodecError>;
 }
 
+/// A trait for encoding and decoding PLDM messages with explicit lifetime requirements.
+///
+/// This trait is similar to `PldmCodec` but supports types that borrow data from the buffer
+/// during decoding, requiring an explicit lifetime parameter.
+pub trait PldmCodecWithLifetime<'a>: core::fmt::Debug + Sized {
+    /// Encodes the PLDM message into the provided byte buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - A mutable reference to a byte slice where the encoded message will be stored.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the size of the encoded message on success, or a `PldmCodecError` on failure.
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, PldmCodecError>;
+
+    /// Decodes a PLDM message from the provided byte buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `buffer` - A reference to a byte slice containing the encoded message. The decoded
+    ///   type may hold references to this buffer.
+    ///
+    /// # Returns
+    ///
+    /// A `Result` containing the decoded message on success, or a `PldmCodecError` on failure.
+    fn decode(buffer: &'a [u8]) -> Result<Self, PldmCodecError>;
+}
+
 // Default implementation of PldmCodec for types that can leverage zerocopy.
 impl<T> PldmCodec for T
 where

--- a/src/message/firmware_update/get_fw_params.rs
+++ b/src/message/firmware_update/get_fw_params.rs
@@ -331,32 +331,71 @@ mod test {
     }
 
     #[test]
-    fn test_get_firmware_parameters_request() {
+    fn test_get_firmware_parameters_request_codec() {
         let request = GetFirmwareParametersRequest::new(0, PldmMsgType::Request);
         let mut buffer = [0u8; PLDM_MSG_HEADER_LEN];
         request.encode(&mut buffer).unwrap();
+
         let decoded_request = GetFirmwareParametersRequest::decode(&buffer).unwrap();
         assert_eq!(request, decoded_request);
+
+        // Test buffer too short error
+        let mut buffer = [0u8; PLDM_MSG_HEADER_LEN - 1];
+        assert_eq!(
+            request.encode(&mut buffer).unwrap_err(),
+            PldmCodecError::BufferTooShort
+        );
+
+        assert_eq!(
+            GetFirmwareParametersRequest::decode(&buffer).unwrap_err(),
+            PldmCodecError::BufferTooShort
+        );
     }
 
     #[test]
-    fn test_get_firmware_parameters() {
+    fn test_get_firmware_parameters_codec() {
         let firmware_parameters = construct_firmware_params();
         let mut buffer = [0u8; 1024];
         let size = firmware_parameters.encode(&mut buffer).unwrap();
         assert_eq!(size, firmware_parameters.codec_size_in_bytes());
+
         let decoded_firmware_parameters = FirmwareParameters::decode(&buffer[..size]).unwrap();
         assert_eq!(firmware_parameters, decoded_firmware_parameters);
+
+        // Test buffer too short error
+        let mut short_buffer = [0u8; 1];
+        assert_eq!(
+            firmware_parameters.encode(&mut short_buffer).unwrap_err(),
+            PldmCodecError::BufferTooShort
+        );
+
+        assert_eq!(
+            FirmwareParameters::decode(&short_buffer).unwrap_err(),
+            PldmCodecError::BufferTooShort
+        );
     }
 
     #[test]
-    fn test_get_firmware_parameters_response() {
+    fn test_get_firmware_parameters_response_codec() {
         let firmware_parameters = construct_firmware_params();
         let response = GetFirmwareParametersResponse::new(0, 0, &firmware_parameters);
         let mut buffer = [0u8; 1024];
         let size = response.encode(&mut buffer).unwrap();
         assert_eq!(size, response.codec_size_in_bytes());
+
         let decoded_response = GetFirmwareParametersResponse::decode(&buffer[..size]).unwrap();
         assert_eq!(response, decoded_response);
+
+        // Test buffer too short error
+        let mut short_buffer = [0u8; 1];
+        assert_eq!(
+            response.encode(&mut short_buffer).unwrap_err(),
+            PldmCodecError::BufferTooShort
+        );
+
+        assert_eq!(
+            GetFirmwareParametersResponse::decode(&short_buffer).unwrap_err(),
+            PldmCodecError::BufferTooShort
+        );
     }
 }

--- a/src/message/firmware_update/get_fw_params.rs
+++ b/src/message/firmware_update/get_fw_params.rs
@@ -257,8 +257,7 @@ impl PldmCodec for GetFirmwareParametersResponse {
         offset += core::mem::size_of::<u8>();
 
         let bytes = self.parms.encode(&mut buffer[offset..])?;
-        offset += bytes;
-        Ok(offset)
+        Ok(offset + bytes)
     }
 
     fn decode(buffer: &[u8]) -> Result<Self, PldmCodecError> {

--- a/src/message/firmware_update/get_package_data.rs
+++ b/src/message/firmware_update/get_package_data.rs
@@ -213,6 +213,99 @@ impl<'a> GetDeviceMetaDataResponse<'a> {
     }
 }
 
+/// The FD sends this command to transfer the data that was originally obtained by the UA through the
+/// [GetDeviceMetaData] command. This command shall only be used if the FD indicated in the
+/// [RequestUpdate] response that it had device metadata that needed to be obtained by the UA. The FD can
+/// send this command when it is in any state, except the IDLE and LEARN COMPONENTS state.
+pub struct GetMetaDataRequest {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+    pub data_transfer_handle: u32,
+    pub transfer_operation_flag: u8,
+}
+
+impl GetMetaDataRequest {
+    pub fn new(
+        instance_id: InstanceId,
+        data_transfer_handle: u32,
+        transfer_operation_flag: TransferOperationFlag,
+    ) -> Self {
+        GetMetaDataRequest {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Request,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::GetMetaData as u8,
+            ),
+            data_transfer_handle,
+            transfer_operation_flag: transfer_operation_flag as u8,
+        }
+    }
+}
+
+pub enum GetMetaDataCodes {
+    BaseCodes(protocol::base::PldmBaseCompletionCode),
+    CommandNotExpected,
+    InvalidTransferHandle,
+    InvalidTransferOperationFlag,
+}
+
+impl From<GetMetaDataCodes> for u8 {
+    fn from(code: GetMetaDataCodes) -> Self {
+        match code {
+            GetMetaDataCodes::BaseCodes(code) => code as u8,
+            GetMetaDataCodes::CommandNotExpected => {
+                FwUpdateCompletionCode::CommandNotExpected as u8
+            }
+            GetMetaDataCodes::InvalidTransferHandle => {
+                FwUpdateCompletionCode::InvalidTransferHandle as u8
+            }
+            GetMetaDataCodes::InvalidTransferOperationFlag => {
+                FwUpdateCompletionCode::InvalidTransferOperationFlag as u8
+            }
+        }
+    }
+}
+
+pub struct GetMetaDataResponse<'a> {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+
+    /// PLDM_BASE_CODES, COMMAND_NOT_EXPECTED, INVALID_TRANSFER_HANDLE,
+    /// INVALID_TRANSFER_OPERATION_FLAG
+    pub completion_code: u8,
+    pub next_data_transfer_handle: u32,
+    pub transfer_flag: u8,
+
+    /// The UA should select the amount of data to return such that the byte length for this field, except
+    /// when TransferFlag = End or StartAndEnd, is equal to or between the values of the firmware update
+    /// baseline transfer size and MaximumTransferSize from the [RequestUpdate] or
+    /// [RequestDownstreamDeviceUpdate] command. When TransferFlag = End or StartAndEnd, the
+    /// variable size of this field can also be less than the firmware update baseline transfer size.
+    pub portion_of_device_metadata: &'a [u8],
+}
+
+impl<'a> GetMetaDataResponse<'a> {
+    pub fn new(
+        instance_id: InstanceId,
+        completion_code: GetMetaDataCodes,
+        next_data_transfer_handle: u32,
+        transfer_flag: TransferOperationFlag,
+        portion_of_device_metadata: &'a [u8],
+    ) -> Self {
+        GetMetaDataResponse {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Response,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::GetMetaData as u8,
+            ),
+            completion_code: completion_code.into(),
+            next_data_transfer_handle,
+            transfer_flag: transfer_flag as u8,
+            portion_of_device_metadata,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::protocol;

--- a/src/message/firmware_update/get_package_data.rs
+++ b/src/message/firmware_update/get_package_data.rs
@@ -1,0 +1,147 @@
+// Licensed under the Apache-2.0 license
+
+use crate::protocol;
+use crate::protocol::base::{
+    InstanceId, PldmMsgHeader, PldmMsgType, PldmSupportedType, TransferOperationFlag,
+    PLDM_MSG_HEADER_LEN,
+};
+
+use crate::protocol::firmware_update::{FwUpdateCmd, FwUpdateCompletionCode};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+pub const GET_PACKAGE_DATA_PORTION_SIZE: usize = 1024;
+
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[repr(C, packed)]
+/// The FD sends this command to transfer optional data that shall be received prior to transferring
+/// components during the firmware update process. This command is only used if the firmware update
+/// package contained content within the [FirmwareDevicePackageData] field, the UA provided the length of
+/// the package data in the RequestUpdate command, and the FD indicated that it would use this command
+/// in the [FDWillSendGetPackageDataCommand] field.
+pub struct GetPackageDataRequest {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+    pub data_transfer_handle: u32,
+    pub transfer_operation_flag: u8,
+}
+
+impl GetPackageDataRequest {
+    pub fn new(
+        instance_id: InstanceId,
+        data_transfer_handle: u32,
+        transfer_operation_flag: TransferOperationFlag,
+    ) -> Self {
+        GetPackageDataRequest {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Request,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::GetPackageData as u8,
+            ),
+            data_transfer_handle,
+            transfer_operation_flag: transfer_operation_flag as u8,
+        }
+    }
+}
+
+pub enum GetPackageDataCodes {
+    BaseCodes(protocol::base::PldmBaseCompletionCode),
+    CommandNotExpected,
+    NoPackageData,
+    InvalidTransferHandle,
+    InvalidTransferOperationFlag,
+}
+
+impl From<GetPackageDataCodes> for u8 {
+    fn from(code: GetPackageDataCodes) -> Self {
+        match code {
+            GetPackageDataCodes::BaseCodes(code) => code as u8,
+            GetPackageDataCodes::CommandNotExpected => {
+                FwUpdateCompletionCode::CommandNotExpected as u8
+            }
+            GetPackageDataCodes::NoPackageData => FwUpdateCompletionCode::NoPackageData as u8,
+            GetPackageDataCodes::InvalidTransferHandle => {
+                FwUpdateCompletionCode::InvalidTransferHandle as u8
+            }
+            GetPackageDataCodes::InvalidTransferOperationFlag => {
+                FwUpdateCompletionCode::InvalidTransferOperationFlag as u8
+            }
+        }
+    }
+}
+
+pub struct GetPackageDataResponse<'a> {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+
+    /// PLDM_BASE_CODES, COMMAND_NOT_EXPECTED, NO_PACKAGE_DATA, INVALID_TRANSFER_HANDLE, INVALID_TRANSFER_OPERATION_FLAG
+    pub completion_code: u8,
+    pub next_data_transfer_handle: u32,
+    pub transfer_flag: u8,
+
+    /// If the FD provided a value in the GetPackageDataMaximumTransferSize field, then the UA should
+    /// select the amount of data to return such that the byte length for this field, except when TransferFlag
+    /// = End or StartAndEnd, is equal to or less than that value.
+    pub portion_of_package_data: &'a [u8],
+}
+
+impl<'a> GetPackageDataResponse<'a> {
+    pub fn new(
+        instance_id: InstanceId,
+        completion_code: GetPackageDataCodes,
+        next_data_transfer_handle: u32,
+        transfer_flag: TransferOperationFlag,
+        portion_of_package_data: &'a [u8],
+    ) -> Self {
+        GetPackageDataResponse {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Response,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::GetPackageData as u8,
+            ),
+            completion_code: completion_code.into(),
+            next_data_transfer_handle,
+            transfer_flag: transfer_flag as u8,
+            portion_of_package_data,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::protocol;
+
+    use super::*;
+
+    //TODO: Add a test that behaves like the example in DSP0267, Fig. 11
+    //TODO: take ensure that the creation of these packages fits to the
+    // description of Table 28, PortionOfPackageData Field
+    #[test]
+    fn test_package_data_flow() {
+        let instance_id: InstanceId = 0x01;
+        //TODO: use FwUpdateCompletionCode
+        let completion_code =
+            GetPackageDataCodes::BaseCodes(protocol::base::PldmBaseCompletionCode::Success);
+        let next_data_transfer_handle: u32 = 0x00000010;
+        let transfer_flag = TransferOperationFlag::GetFirstPart;
+        let portion_of_package_data: &[u8] = &[0xAA; GET_PACKAGE_DATA_PORTION_SIZE];
+
+        let response = GetPackageDataResponse::new(
+            instance_id,
+            completion_code,
+            next_data_transfer_handle,
+            transfer_flag,
+            portion_of_package_data,
+        );
+        assert_eq!(response.hdr.rq(), PldmMsgType::Response as u8);
+        assert_eq!(
+            response.completion_code,
+            GetPackageDataCodes::BaseCodes(protocol::base::PldmBaseCompletionCode::Success).into()
+        );
+        assert_eq!(
+            response.next_data_transfer_handle,
+            next_data_transfer_handle
+        );
+        assert_eq!(response.transfer_flag, transfer_flag as u8);
+        assert_eq!(response.portion_of_package_data, portion_of_package_data);
+    }
+}

--- a/src/message/firmware_update/get_package_data.rs
+++ b/src/message/firmware_update/get_package_data.rs
@@ -17,9 +17,9 @@ pub const GET_PACKAGE_DATA_PORTION_SIZE: usize = 1024;
 #[repr(C, packed)]
 /// The FD sends this command to transfer optional data that shall be received prior to transferring
 /// components during the firmware update process. This command is only used if the firmware update
-/// package contained content within the [FirmwareDevicePackageData] field, the UA provided the length of
+/// package contained content within the FirmwareDevicePackageData field, the UA provided the length of
 /// the package data in the RequestUpdate command, and the FD indicated that it would use this command
-/// in the [FDWillSendGetPackageDataCommand] field.
+/// in the FDWillSendGetPackageDataCommand field.
 pub struct GetPackageDataRequest {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
     pub data_transfer_handle: u32,
@@ -120,19 +120,16 @@ impl PldmCodec for GetPackageDataResponse {
             return Err(PldmCodecError::BufferTooShort);
         }
 
-        dbg!(core::mem::size_of::<GetPackageDataResponse>());
-
         let mut offset = 0;
-        buffer[offset..offset + std::mem::size_of_val(&self.hdr.0)].copy_from_slice(&self.hdr.0);
-        offset += std::mem::size_of_val(&self.hdr.0);
-        dbg!(offset);
+        buffer[offset..offset + size_of_val(&self.hdr.0)].copy_from_slice(&self.hdr.0);
+        offset += size_of_val(&self.hdr.0);
 
         buffer[offset] = self.completion_code;
         offset += 1;
 
-        buffer[offset..offset + std::mem::size_of_val(&self.next_data_transfer_handle)]
+        buffer[offset..offset + size_of_val(&self.next_data_transfer_handle)]
             .copy_from_slice(self.next_data_transfer_handle.as_bytes());
-        offset += std::mem::size_of_val(&self.next_data_transfer_handle);
+        offset += size_of_val(&self.next_data_transfer_handle);
 
         buffer[offset] = self.transfer_flag;
         offset += 1;
@@ -141,11 +138,7 @@ impl PldmCodec for GetPackageDataResponse {
             self.portion_of_package_data[0..self.portion_of_package_data_len].as_bytes(),
         );
 
-        offset += self.portion_of_package_data_len;
-        dbg!(&buffer, &buffer.len(), &self.portion_of_package_data_len);
-        dbg!(self.portion_of_package_data_len);
-
-        Ok(offset)
+        Ok(offset + self.portion_of_package_data_len)
     }
 
     fn decode(buffer: &[u8]) -> Result<Self, crate::codec::PldmCodecError> {
@@ -309,7 +302,7 @@ impl<'a> PldmCodecWithLifetime<'a> for GetDeviceMetaDataResponse<'a> {
         buffer[offset..offset + self.portion_of_device_metadata.len()]
             .copy_from_slice(self.portion_of_device_metadata);
 
-        Ok(size)
+        Ok(offset + self.portion_of_device_metadata.len())
     }
 
     fn decode(buffer: &'a [u8]) -> Result<Self, PldmCodecError> {
@@ -350,8 +343,8 @@ impl<'a> PldmCodecWithLifetime<'a> for GetDeviceMetaDataResponse<'a> {
 }
 
 /// The FD sends this command to transfer the data that was originally obtained by the UA through the
-/// [GetDeviceMetaData] command. This command shall only be used if the FD indicated in the
-/// [RequestUpdate] response that it had device metadata that needed to be obtained by the UA. The FD can
+/// [GetDeviceMetaDataRequest] command. This command shall only be used if the FD indicated in the
+/// RequestUpdate response that it had device metadata that needed to be obtained by the UA. The FD can
 /// send this command when it is in any state, except the IDLE and LEARN COMPONENTS state.
 #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
 #[repr(C, packed)]
@@ -403,9 +396,10 @@ pub struct GetMetaDataResponse<'a> {
 
     /// The UA should select the amount of data to return such that the byte length for this field, except
     /// when TransferFlag = End or StartAndEnd, is equal to or between the values of the firmware update
-    /// baseline transfer size and MaximumTransferSize from the [RequestUpdate] or
-    /// [RequestDownstreamDeviceUpdate] command. When TransferFlag = End or StartAndEnd, the
-    /// variable size of this field can also be less than the firmware update baseline transfer size.
+    /// baseline transfer size and MaximumTransferSize from the RequestUpdate or
+    /// [crate::message::firmware_update::query_downstream::RequestDownstreamDeviceUpdateRequest] command.
+    ///  When TransferFlag = End or StartAndEnd, the variable size of this field can also be less than
+    /// the firmware update baseline transfer size.
     pub portion_of_device_metadata: &'a [u8],
 }
 
@@ -457,7 +451,7 @@ impl<'a> PldmCodecWithLifetime<'a> for GetMetaDataResponse<'a> {
         buffer[offset..offset + self.portion_of_device_metadata.len()]
             .copy_from_slice(self.portion_of_device_metadata);
 
-        Ok(size)
+        Ok(offset + self.portion_of_device_metadata.len())
     }
 
     fn decode(buffer: &'a [u8]) -> Result<Self, PldmCodecError> {

--- a/src/message/firmware_update/get_package_data.rs
+++ b/src/message/firmware_update/get_package_data.rs
@@ -283,6 +283,72 @@ impl<'a> GetDeviceMetaDataResponse<'a> {
     }
 }
 
+impl<'a> PldmCodecWithLifetime<'a> for GetDeviceMetaDataResponse<'a> {
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, PldmCodecError> {
+        let size = core::mem::size_of::<Self>() - core::mem::size_of::<&'a [u8]>();
+        if buffer.len() < size + self.portion_of_device_metadata.len() {
+            return Err(PldmCodecError::BufferTooShort);
+        }
+
+        let mut offset = 0;
+        self.hdr
+            .write_to_prefix(&mut buffer[offset..])
+            .map_err(|_| PldmCodecError::BufferTooShort)?;
+        offset += PLDM_MSG_HEADER_LEN;
+
+        buffer[offset] = self.completion_code;
+        offset += 1;
+
+        buffer[offset..offset + size_of::<u32>()]
+            .copy_from_slice(&self.next_data_transfer_handle.to_le_bytes());
+        offset += size_of::<u32>();
+
+        buffer[offset] = self.transfer_flag;
+        offset += size_of::<u8>();
+
+        buffer[offset..offset + self.portion_of_device_metadata.len()]
+            .copy_from_slice(self.portion_of_device_metadata);
+
+        Ok(size)
+    }
+
+    fn decode(buffer: &'a [u8]) -> Result<Self, PldmCodecError> {
+        let size = core::mem::size_of::<Self>() - core::mem::size_of::<&'a [u8]>();
+        if buffer.len() < size {
+            return Err(PldmCodecError::BufferTooShort);
+        }
+
+        let mut offset = 0;
+        let hdr = PldmMsgHeader::read_from_prefix(&buffer[offset..])
+            .map_err(|_| PldmCodecError::BufferTooShort)?
+            .0;
+        offset += PLDM_MSG_HEADER_LEN;
+
+        let completion_code = buffer[offset];
+        offset += size_of::<u8>();
+
+        let next_data_transfer_handle = u32::from_le_bytes(
+            buffer[offset..offset + 4]
+                .try_into()
+                .map_err(|_| PldmCodecError::BufferTooShort)?,
+        );
+        offset += size_of::<u32>();
+
+        let transfer_flag = buffer[offset];
+        offset += size_of::<u8>();
+
+        let portion_of_device_metadata = &buffer[offset..];
+
+        Ok(Self {
+            hdr,
+            completion_code,
+            next_data_transfer_handle,
+            transfer_flag,
+            portion_of_device_metadata,
+        })
+    }
+}
+
 /// The FD sends this command to transfer the data that was originally obtained by the UA through the
 /// [GetDeviceMetaData] command. This command shall only be used if the FD indicated in the
 /// [RequestUpdate] response that it had device metadata that needed to be obtained by the UA. The FD can
@@ -438,7 +504,7 @@ mod tests {
     use crate::codec::PldmCodec;
 
     #[test]
-    fn test_get_package_data_request() {
+    fn test_get_package_data_request_codec() {
         let instance_id: InstanceId = 0x01;
         let data_transfer_handle: u32 = 0x12345678;
         let transfer_operation_flag = TransferOperationFlag::GetFirstPart;
@@ -454,7 +520,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_package_data_response() {
+    fn test_get_package_data_response_codec() {
         const PORTION_LEN: usize = 10;
 
         let instance_id: InstanceId = 0x01;
@@ -475,15 +541,13 @@ mod tests {
             - core::mem::size_of::<usize>()
             + PORTION_LEN];
 
-        dbg!(&buffer_fitted.len());
-
         resp.encode(&mut buffer_fitted).unwrap();
         let decoded = GetPackageDataResponse::decode(&buffer_fitted).unwrap();
         assert_eq!(resp, decoded);
     }
 
     #[test]
-    fn test_get_device_metadata_request() {
+    fn test_get_metadata_request_codec() {
         let instance_id: InstanceId = 0x01;
         let data_transfer_handle = 0x12345678;
         let req = GetMetaDataRequest::new(
@@ -500,7 +564,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_device_metadata_response() {
+    fn test_get_meta_data_response_codec() {
         let instance_id: InstanceId = 0x01;
         let data_transfer_handle = 0x12345678;
         let payload = [11u8; 20];
@@ -513,10 +577,52 @@ mod tests {
             &payload,
         );
 
-        let mut buffer = [0u8; 9 + 20];
+        let mut buffer =
+            [0u8; core::mem::size_of::<GetMetaDataResponse>() - core::mem::size_of::<&[u8]>() + 20];
         resp.encode(&mut buffer).unwrap();
 
         let decoded = GetMetaDataResponse::decode(&mut buffer).unwrap();
+        assert_eq!(resp, decoded);
+    }
+
+    #[test]
+    fn test_get_device_meta_data_request_codec() {
+        let instance_id: InstanceId = 0x01;
+        let data_transfer_handle = 0x12345678;
+        let req = GetDeviceMetaDataRequest::new(
+            instance_id,
+            data_transfer_handle,
+            TransferOperationFlag::GetFirstPart,
+        );
+
+        let mut buffer = [0u8; core::mem::size_of::<GetDeviceMetaDataRequest>()];
+        req.encode(&mut buffer).unwrap();
+
+        let decoded = GetDeviceMetaDataRequest::decode(&buffer).unwrap();
+        assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn test_get_device_meta_data_response_codec() {
+        let instance_id: InstanceId = 0x01;
+        let data_transfer_handle = 0x12345678;
+        const TEST_PAYLOAD_LEN: usize = 20;
+        let payload = [11u8; TEST_PAYLOAD_LEN];
+
+        let resp = GetDeviceMetaDataResponse::new(
+            instance_id,
+            GetDeviceMetaDataCodes::BaseCodes(PldmBaseCompletionCode::Success),
+            data_transfer_handle,
+            TransferOperationFlag::GetFirstPart,
+            &payload,
+        );
+
+        let mut buffer = [0u8; core::mem::size_of::<GetDeviceMetaDataResponse>()
+            - core::mem::size_of::<&[u8]>()
+            + TEST_PAYLOAD_LEN];
+        resp.encode(&mut buffer).unwrap();
+
+        let decoded = GetDeviceMetaDataResponse::decode(&mut buffer).unwrap();
         assert_eq!(resp, decoded);
     }
 }

--- a/src/message/firmware_update/get_package_data.rs
+++ b/src/message/firmware_update/get_package_data.rs
@@ -72,7 +72,10 @@ impl From<GetPackageDataCodes> for u8 {
 pub struct GetPackageDataResponse<'a> {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
 
-    /// PLDM_BASE_CODES, COMMAND_NOT_EXPECTED, NO_PACKAGE_DATA, INVALID_TRANSFER_HANDLE, INVALID_TRANSFER_OPERATION_FLAG
+    /// PLDM_BASE_CODES, COMMAND_NOT_EXPECTED, NO_PACKAGE_DATA,
+    /// INVALID_TRANSFER_HANDLE, INVALID_TRANSFER_OPERATION_FLAG
+    ///
+    /// See [GetPackageDataCodes]
     pub completion_code: u8,
     pub next_data_transfer_handle: u32,
     pub transfer_flag: u8,
@@ -106,6 +109,110 @@ impl<'a> GetPackageDataResponse<'a> {
     }
 }
 
+/// The UA sends this command to acquire optional data that the FD shall transfer to the UA prior to
+/// beginning the transfer of component images. This command is only used if the FD has indicated in the
+/// RequestUpdate command response that it has data that shall be retrieved and restored by the UA. The
+/// firmware device metadata retrieved by this command will be sent back to the FD through the
+/// GetMetaData command after all component images have been transferred.
+pub struct GetDeviceMetaDataRequest {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+    pub data_transfer_handle: u32,
+    pub transfer_operation_flag: u8,
+}
+
+impl GetDeviceMetaDataRequest {
+    pub fn new(
+        instance_id: InstanceId,
+        data_transfer_handle: u32,
+        transfer_operation_flag: TransferOperationFlag,
+    ) -> Self {
+        GetDeviceMetaDataRequest {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Request,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::GetDeviceMetaData as u8,
+            ),
+            data_transfer_handle,
+            transfer_operation_flag: transfer_operation_flag as u8,
+        }
+    }
+}
+
+pub enum GetDeviceMetaDataCodes {
+    BaseCodes(protocol::base::PldmBaseCompletionCode),
+    InvalidStateForCommand,
+    NoDeviceMetadata,
+    InvalidTransferHandle,
+    InvalidTransferOperationFlag,
+    PackageDataError,
+}
+
+impl From<GetDeviceMetaDataCodes> for u8 {
+    fn from(code: GetDeviceMetaDataCodes) -> Self {
+        match code {
+            GetDeviceMetaDataCodes::BaseCodes(code) => code as u8,
+            GetDeviceMetaDataCodes::InvalidStateForCommand => {
+                FwUpdateCompletionCode::InvalidStateForCommand as u8
+            }
+            GetDeviceMetaDataCodes::NoDeviceMetadata => {
+                FwUpdateCompletionCode::NoDeviceMetadata as u8
+            }
+            GetDeviceMetaDataCodes::InvalidTransferHandle => {
+                FwUpdateCompletionCode::InvalidTransferHandle as u8
+            }
+            GetDeviceMetaDataCodes::InvalidTransferOperationFlag => {
+                FwUpdateCompletionCode::InvalidTransferOperationFlag as u8
+            }
+            GetDeviceMetaDataCodes::PackageDataError => {
+                FwUpdateCompletionCode::PackageDataError as u8
+            }
+        }
+    }
+}
+
+pub struct GetDeviceMetaDataResponse<'a> {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+
+    /// PLDM_BASE_CODES, INVALID_STATE_FOR_COMMAND, NO_DEVICE_METADATA,
+    /// INVALID_TRANSFER_HANDLE, INVALID_TRANSFER_OPERATION_FLAG, PACKAGE_DATA_ERROR
+    ///
+    /// See [GetDeviceMetaDataCodes]
+    pub completion_code: u8,
+    pub next_data_transfer_handle: u32,
+    pub transfer_flag: u8,
+
+    /// The FD should select the amount of data to return such that the byte length for this field, except
+    /// when TransferFlag = End or StartAndEnd, is equal to or between the values of the firmware update
+    /// baseline transfer size and MaximumTransferSize from the RequestUpdate or
+    /// RequestDownstreamDeviceUpdate command. When TransferFlag = End or StartAndEnd, the
+    /// variable size of this field can also be less than the firmware update baseline transfer size.
+    pub portion_of_device_metadata: &'a [u8],
+}
+
+impl<'a> GetDeviceMetaDataResponse<'a> {
+    pub fn new(
+        instance_id: InstanceId,
+        completion_code: GetDeviceMetaDataCodes,
+        next_data_transfer_handle: u32,
+        transfer_flag: TransferOperationFlag,
+        portion_of_device_metadata: &'a [u8],
+    ) -> Self {
+        GetDeviceMetaDataResponse {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Response,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::GetDeviceMetaData as u8,
+            ),
+            completion_code: completion_code.into(),
+            next_data_transfer_handle,
+            transfer_flag: transfer_flag as u8,
+            portion_of_device_metadata,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use crate::protocol;
@@ -116,7 +223,7 @@ mod tests {
     //TODO: take ensure that the creation of these packages fits to the
     // description of Table 28, PortionOfPackageData Field
     #[test]
-    fn test_package_data_flow() {
+    fn test_get_package_data() {
         let instance_id: InstanceId = 0x01;
         //TODO: use FwUpdateCompletionCode
         let completion_code =
@@ -143,5 +250,38 @@ mod tests {
         );
         assert_eq!(response.transfer_flag, transfer_flag as u8);
         assert_eq!(response.portion_of_package_data, portion_of_package_data);
+    }
+
+    #[test]
+    fn test_get_device_metadata() {
+        let instance_id: InstanceId = 0x01;
+        let completion_code =
+            GetDeviceMetaDataCodes::BaseCodes(protocol::base::PldmBaseCompletionCode::Success);
+        let next_data_transfer_handle: u32 = 0x00000020;
+        let transfer_flag = TransferOperationFlag::GetFirstPart;
+        let portion_of_device_metadata: &[u8] = &[0xBB; 0xff];
+        let response = GetDeviceMetaDataResponse::new(
+            instance_id,
+            completion_code,
+            next_data_transfer_handle,
+            transfer_flag,
+            portion_of_device_metadata,
+        );
+
+        assert_eq!(response.hdr.rq(), PldmMsgType::Response as u8);
+        assert_eq!(
+            response.completion_code,
+            GetDeviceMetaDataCodes::BaseCodes(protocol::base::PldmBaseCompletionCode::Success)
+                .into()
+        );
+        assert_eq!(
+            response.next_data_transfer_handle,
+            next_data_transfer_handle
+        );
+        assert_eq!(response.transfer_flag, transfer_flag as u8);
+        assert_eq!(
+            response.portion_of_device_metadata,
+            portion_of_device_metadata
+        );
     }
 }

--- a/src/message/firmware_update/get_package_data.rs
+++ b/src/message/firmware_update/get_package_data.rs
@@ -1,10 +1,11 @@
 // Licensed under the Apache-2.0 license
 
-use crate::protocol;
 use crate::protocol::base::{
-    InstanceId, PldmMsgHeader, PldmMsgType, PldmSupportedType, TransferOperationFlag,
-    PLDM_MSG_HEADER_LEN,
+    InstanceId, PldmBaseCompletionCode, PldmMsgHeader, PldmMsgType, PldmSupportedType,
+    TransferOperationFlag, PLDM_MSG_HEADER_LEN,
 };
+
+use crate::pldm_completion_code;
 
 use crate::protocol::firmware_update::{FwUpdateCmd, FwUpdateCompletionCode};
 use zerocopy::{FromBytes, Immutable, IntoBytes};
@@ -43,39 +44,24 @@ impl GetPackageDataRequest {
     }
 }
 
-pub enum GetPackageDataCodes {
-    BaseCodes(protocol::base::PldmBaseCompletionCode),
-    CommandNotExpected,
-    NoPackageData,
-    InvalidTransferHandle,
-    InvalidTransferOperationFlag,
-}
-
-impl From<GetPackageDataCodes> for u8 {
-    fn from(code: GetPackageDataCodes) -> Self {
-        match code {
-            GetPackageDataCodes::BaseCodes(code) => code as u8,
-            GetPackageDataCodes::CommandNotExpected => {
-                FwUpdateCompletionCode::CommandNotExpected as u8
-            }
-            GetPackageDataCodes::NoPackageData => FwUpdateCompletionCode::NoPackageData as u8,
-            GetPackageDataCodes::InvalidTransferHandle => {
-                FwUpdateCompletionCode::InvalidTransferHandle as u8
-            }
-            GetPackageDataCodes::InvalidTransferOperationFlag => {
-                FwUpdateCompletionCode::InvalidTransferOperationFlag as u8
-            }
-        }
+pldm_completion_code! {
+    GetPackageDataCode {
+        CommandNotExpected,
+        NoPackageData,
+        InvalidTransferHandle,
+        InvalidTransferOperationFlag
     }
 }
 
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[repr(C, packed)]
 pub struct GetPackageDataResponse<'a> {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
 
     /// PLDM_BASE_CODES, COMMAND_NOT_EXPECTED, NO_PACKAGE_DATA,
     /// INVALID_TRANSFER_HANDLE, INVALID_TRANSFER_OPERATION_FLAG
     ///
-    /// See [GetPackageDataCodes]
+    /// See [GetPackageDataCode]
     pub completion_code: u8,
     pub next_data_transfer_handle: u32,
     pub transfer_flag: u8,
@@ -89,7 +75,7 @@ pub struct GetPackageDataResponse<'a> {
 impl<'a> GetPackageDataResponse<'a> {
     pub fn new(
         instance_id: InstanceId,
-        completion_code: GetPackageDataCodes,
+        completion_code: GetPackageDataCode,
         next_data_transfer_handle: u32,
         transfer_flag: TransferOperationFlag,
         portion_of_package_data: &'a [u8],
@@ -114,6 +100,9 @@ impl<'a> GetPackageDataResponse<'a> {
 /// RequestUpdate command response that it has data that shall be retrieved and restored by the UA. The
 /// firmware device metadata retrieved by this command will be sent back to the FD through the
 /// GetMetaData command after all component images have been transferred.
+///
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[repr(C, packed)]
 pub struct GetDeviceMetaDataRequest {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
     pub data_transfer_handle: u32,
@@ -139,38 +128,17 @@ impl GetDeviceMetaDataRequest {
     }
 }
 
-pub enum GetDeviceMetaDataCodes {
-    BaseCodes(protocol::base::PldmBaseCompletionCode),
+pldm_completion_code! {
+    GetDeviceMetaDataCodes {
     InvalidStateForCommand,
     NoDeviceMetadata,
     InvalidTransferHandle,
     InvalidTransferOperationFlag,
     PackageDataError,
-}
+}}
 
-impl From<GetDeviceMetaDataCodes> for u8 {
-    fn from(code: GetDeviceMetaDataCodes) -> Self {
-        match code {
-            GetDeviceMetaDataCodes::BaseCodes(code) => code as u8,
-            GetDeviceMetaDataCodes::InvalidStateForCommand => {
-                FwUpdateCompletionCode::InvalidStateForCommand as u8
-            }
-            GetDeviceMetaDataCodes::NoDeviceMetadata => {
-                FwUpdateCompletionCode::NoDeviceMetadata as u8
-            }
-            GetDeviceMetaDataCodes::InvalidTransferHandle => {
-                FwUpdateCompletionCode::InvalidTransferHandle as u8
-            }
-            GetDeviceMetaDataCodes::InvalidTransferOperationFlag => {
-                FwUpdateCompletionCode::InvalidTransferOperationFlag as u8
-            }
-            GetDeviceMetaDataCodes::PackageDataError => {
-                FwUpdateCompletionCode::PackageDataError as u8
-            }
-        }
-    }
-}
-
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[repr(C, packed)]
 pub struct GetDeviceMetaDataResponse<'a> {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
 
@@ -217,6 +185,8 @@ impl<'a> GetDeviceMetaDataResponse<'a> {
 /// [GetDeviceMetaData] command. This command shall only be used if the FD indicated in the
 /// [RequestUpdate] response that it had device metadata that needed to be obtained by the UA. The FD can
 /// send this command when it is in any state, except the IDLE and LEARN COMPONENTS state.
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[repr(C, packed)]
 pub struct GetMetaDataRequest {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
     pub data_transfer_handle: u32,
@@ -242,35 +212,23 @@ impl GetMetaDataRequest {
     }
 }
 
-pub enum GetMetaDataCodes {
-    BaseCodes(protocol::base::PldmBaseCompletionCode),
-    CommandNotExpected,
-    InvalidTransferHandle,
-    InvalidTransferOperationFlag,
-}
-
-impl From<GetMetaDataCodes> for u8 {
-    fn from(code: GetMetaDataCodes) -> Self {
-        match code {
-            GetMetaDataCodes::BaseCodes(code) => code as u8,
-            GetMetaDataCodes::CommandNotExpected => {
-                FwUpdateCompletionCode::CommandNotExpected as u8
-            }
-            GetMetaDataCodes::InvalidTransferHandle => {
-                FwUpdateCompletionCode::InvalidTransferHandle as u8
-            }
-            GetMetaDataCodes::InvalidTransferOperationFlag => {
-                FwUpdateCompletionCode::InvalidTransferOperationFlag as u8
-            }
-        }
+pldm_completion_code! {
+    GetMetaDataCode {
+        CommandNotExpected,
+        InvalidTransferHandle,
+        InvalidTransferOperationFlag,
     }
 }
 
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[repr(C, packed)]
 pub struct GetMetaDataResponse<'a> {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
 
     /// PLDM_BASE_CODES, COMMAND_NOT_EXPECTED, INVALID_TRANSFER_HANDLE,
     /// INVALID_TRANSFER_OPERATION_FLAG
+    ///
+    /// See [GetMetaDataCode]
     pub completion_code: u8,
     pub next_data_transfer_handle: u32,
     pub transfer_flag: u8,
@@ -286,7 +244,7 @@ pub struct GetMetaDataResponse<'a> {
 impl<'a> GetMetaDataResponse<'a> {
     pub fn new(
         instance_id: InstanceId,
-        completion_code: GetMetaDataCodes,
+        completion_code: GetMetaDataCode,
         next_data_transfer_handle: u32,
         transfer_flag: TransferOperationFlag,
         portion_of_device_metadata: &'a [u8],
@@ -308,73 +266,53 @@ impl<'a> GetMetaDataResponse<'a> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::protocol;
 
-    use super::*;
+    use crate::codec::PldmCodec;
 
-    //TODO: Add a test that behaves like the example in DSP0267, Fig. 11
-    //TODO: take ensure that the creation of these packages fits to the
-    // description of Table 28, PortionOfPackageData Field
     #[test]
-    fn test_get_package_data() {
+    fn test_get_package_data_request() {
         let instance_id: InstanceId = 0x01;
-        //TODO: use FwUpdateCompletionCode
-        let completion_code =
-            GetPackageDataCodes::BaseCodes(protocol::base::PldmBaseCompletionCode::Success);
-        let next_data_transfer_handle: u32 = 0x00000010;
-        let transfer_flag = TransferOperationFlag::GetFirstPart;
-        let portion_of_package_data: &[u8] = &[0xAA; GET_PACKAGE_DATA_PORTION_SIZE];
+        let data_transfer_handle: u32 = 0x12345678;
+        let transfer_operation_flag = TransferOperationFlag::GetFirstPart;
 
-        let response = GetPackageDataResponse::new(
-            instance_id,
-            completion_code,
-            next_data_transfer_handle,
-            transfer_flag,
-            portion_of_package_data,
-        );
-        assert_eq!(response.hdr.rq(), PldmMsgType::Response as u8);
-        assert_eq!(
-            response.completion_code,
-            GetPackageDataCodes::BaseCodes(protocol::base::PldmBaseCompletionCode::Success).into()
-        );
-        assert_eq!(
-            response.next_data_transfer_handle,
-            next_data_transfer_handle
-        );
-        assert_eq!(response.transfer_flag, transfer_flag as u8);
-        assert_eq!(response.portion_of_package_data, portion_of_package_data);
+        let request =
+            GetPackageDataRequest::new(instance_id, data_transfer_handle, transfer_operation_flag);
+
+        let mut buffer = [0u8; core::mem::size_of::<GetPackageDataRequest>()];
+        request.encode(&mut buffer).unwrap();
+        let decoded = GetPackageDataRequest::decode(&buffer).unwrap();
+
+        assert_eq!(request, decoded);
     }
 
     #[test]
-    fn test_get_device_metadata() {
+    fn test_get_data_response() {
         let instance_id: InstanceId = 0x01;
-        let completion_code =
-            GetDeviceMetaDataCodes::BaseCodes(protocol::base::PldmBaseCompletionCode::Success);
-        let next_data_transfer_handle: u32 = 0x00000020;
-        let transfer_flag = TransferOperationFlag::GetFirstPart;
-        let portion_of_device_metadata: &[u8] = &[0xBB; 0xff];
-        let response = GetDeviceMetaDataResponse::new(
+        let next_data_transfer_handle: u32 = 0x12345678;
+        let transfer_operation_flag = TransferOperationFlag::GetFirstPart;
+        let portion = [0u8; 0xff];
+
+        let _ = GetPackageDataResponse::new(
             instance_id,
-            completion_code,
+            GetPackageDataCode::BaseCodes(PldmBaseCompletionCode::Success),
             next_data_transfer_handle,
-            transfer_flag,
-            portion_of_device_metadata,
+            transfer_operation_flag,
+            &portion,
         );
 
-        assert_eq!(response.hdr.rq(), PldmMsgType::Response as u8);
-        assert_eq!(
-            response.completion_code,
-            GetDeviceMetaDataCodes::BaseCodes(protocol::base::PldmBaseCompletionCode::Success)
-                .into()
-        );
-        assert_eq!(
-            response.next_data_transfer_handle,
-            next_data_transfer_handle
-        );
-        assert_eq!(response.transfer_flag, transfer_flag as u8);
-        assert_eq!(
-            response.portion_of_device_metadata,
-            portion_of_device_metadata
-        );
+        //TODO: encoding for response does not work atm due to unknown sizes
+        // let mut buffer = [0u8; core::mem::size_of::<GetPackageDataResponse>()];
+        // request.encode(&mut buffer).unwrap();
+        // let decoded = GetPackageDataResponse::decode(&buffer).unwrap();
+
+        // assert_eq!(request, decoded);
     }
+
+    #[test]
+    fn test_get_device_metadata_request() {}
+
+    #[test]
+    fn test_get_device_metadata_reponse() {}
 }

--- a/src/message/firmware_update/get_package_data.rs
+++ b/src/message/firmware_update/get_package_data.rs
@@ -7,6 +7,7 @@ use crate::protocol::base::{
 
 use crate::pldm_completion_code;
 
+use crate::codec::{PldmCodec, PldmCodecError, PldmCodecWithLifetime};
 use crate::protocol::firmware_update::{FwUpdateCmd, FwUpdateCompletionCode};
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
@@ -53,9 +54,11 @@ pldm_completion_code! {
     }
 }
 
-#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
-#[repr(C, packed)]
-pub struct GetPackageDataResponse<'a> {
+const MAX_PORTION_DATA_SIZE: usize = 0xff;
+#[derive(Debug, Clone, PartialEq, FromBytes)]
+#[repr(C)]
+/// GetPackageDataResponse is parameterized over the portion package data size.
+pub struct GetPackageDataResponse {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
 
     /// PLDM_BASE_CODES, COMMAND_NOT_EXPECTED, NO_PACKAGE_DATA,
@@ -69,17 +72,26 @@ pub struct GetPackageDataResponse<'a> {
     /// If the FD provided a value in the GetPackageDataMaximumTransferSize field, then the UA should
     /// select the amount of data to return such that the byte length for this field, except when TransferFlag
     /// = End or StartAndEnd, is equal to or less than that value.
-    pub portion_of_package_data: &'a [u8],
+    pub portion_of_package_data: [u8; MAX_PORTION_DATA_SIZE],
+
+    // Non-spec field. Since the spec tells us that this can vary in unknown size,
+    // we save the max and keep track of the actual size in this var.
+    // When encoding this into byte form, we have to omit this field and only
+    // encode as many bytes of [portion_of_package] as [portion_of_package_data_len]
+    // tells us to.
+    portion_of_package_data_len: usize,
 }
 
-impl<'a> GetPackageDataResponse<'a> {
+impl GetPackageDataResponse {
     pub fn new(
         instance_id: InstanceId,
         completion_code: GetPackageDataCode,
         next_data_transfer_handle: u32,
         transfer_flag: TransferOperationFlag,
-        portion_of_package_data: &'a [u8],
+        portion_of_package_data: &[u8],
     ) -> Self {
+        let mut pdata: [u8; MAX_PORTION_DATA_SIZE] = [0x00; MAX_PORTION_DATA_SIZE];
+        pdata[0..portion_of_package_data.len()].copy_from_slice(portion_of_package_data);
         GetPackageDataResponse {
             hdr: PldmMsgHeader::new(
                 instance_id,
@@ -90,8 +102,98 @@ impl<'a> GetPackageDataResponse<'a> {
             completion_code: completion_code.into(),
             next_data_transfer_handle,
             transfer_flag: transfer_flag as u8,
-            portion_of_package_data,
+            portion_of_package_data: pdata,
+            portion_of_package_data_len: portion_of_package_data.len(),
         }
+    }
+}
+
+// See: src/message/firmware_update/get_fw_params.rs for manual decode etc
+impl PldmCodec for GetPackageDataResponse {
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, crate::codec::PldmCodecError> {
+        if buffer.len()
+            < core::mem::size_of::<GetPackageDataResponse>()
+                - MAX_PORTION_DATA_SIZE
+                - core::mem::size_of_val(&self.portion_of_package_data_len)
+                + self.portion_of_package_data_len
+        {
+            return Err(PldmCodecError::BufferTooShort);
+        }
+
+        dbg!(core::mem::size_of::<GetPackageDataResponse>());
+
+        let mut offset = 0;
+        buffer[offset..offset + std::mem::size_of_val(&self.hdr.0)].copy_from_slice(&self.hdr.0);
+        offset += std::mem::size_of_val(&self.hdr.0);
+        dbg!(offset);
+
+        buffer[offset] = self.completion_code;
+        offset += 1;
+
+        buffer[offset..offset + std::mem::size_of_val(&self.next_data_transfer_handle)]
+            .copy_from_slice(self.next_data_transfer_handle.as_bytes());
+        offset += std::mem::size_of_val(&self.next_data_transfer_handle);
+
+        buffer[offset] = self.transfer_flag;
+        offset += 1;
+
+        buffer[offset..offset + self.portion_of_package_data_len].copy_from_slice(
+            self.portion_of_package_data[0..self.portion_of_package_data_len].as_bytes(),
+        );
+
+        offset += self.portion_of_package_data_len;
+        dbg!(&buffer, &buffer.len(), &self.portion_of_package_data_len);
+        dbg!(self.portion_of_package_data_len);
+
+        Ok(offset)
+    }
+
+    fn decode(buffer: &[u8]) -> Result<Self, crate::codec::PldmCodecError> {
+        const MIN_LEN: usize = core::mem::size_of::<GetPackageDataResponse>()
+            - core::mem::size_of::<usize>()
+            - core::mem::size_of::<u8>() * MAX_PORTION_DATA_SIZE;
+
+        if buffer.len() < MIN_LEN {
+            return Err(PldmCodecError::BufferTooShort);
+        }
+
+        let mut offset = 0;
+
+        let mut hdr_bytes = [0u8; PLDM_MSG_HEADER_LEN];
+        hdr_bytes.copy_from_slice(&buffer[offset..offset + PLDM_MSG_HEADER_LEN]);
+
+        let hdr = PldmMsgHeader(hdr_bytes);
+        offset += PLDM_MSG_HEADER_LEN;
+
+        let completion_code = GetPackageDataCode::try_from(buffer[offset])
+            .map_err(|_| PldmCodecError::Unsupported)?;
+        offset += 1;
+
+        let next_data_transfer_handle = u32::from_le_bytes([
+            buffer[offset],
+            buffer[offset + 1],
+            buffer[offset + 2],
+            buffer[offset + 3],
+        ]);
+        offset += 4;
+
+        let transfer_flag = TransferOperationFlag::try_from(buffer[offset])
+            .map_err(|_| PldmCodecError::Unsupported)?;
+        offset += 1;
+
+        let portion_len = buffer.len() - offset;
+        if portion_len > MAX_PORTION_DATA_SIZE {
+            return Err(PldmCodecError::BufferTooShort);
+        }
+
+        let portion_data = &buffer[offset..];
+        Ok(Self::new(
+            hdr.instance_id(),
+            completion_code,
+            next_data_transfer_handle,
+            transfer_flag,
+            portion_data,
+        ))
     }
 }
 
@@ -264,11 +366,75 @@ impl<'a> GetMetaDataResponse<'a> {
     }
 }
 
+impl<'a> PldmCodecWithLifetime<'a> for GetMetaDataResponse<'a> {
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, PldmCodecError> {
+        let size = core::mem::size_of::<Self>() - core::mem::size_of::<&'a [u8]>();
+        if buffer.len() < size + self.portion_of_device_metadata.len() {
+            return Err(PldmCodecError::BufferTooShort);
+        }
+
+        let mut offset = 0;
+        self.hdr
+            .write_to_prefix(&mut buffer[offset..])
+            .map_err(|_| PldmCodecError::BufferTooShort)?;
+        offset += PLDM_MSG_HEADER_LEN;
+
+        buffer[offset] = self.completion_code;
+        offset += 1;
+
+        buffer[offset..offset + 4].copy_from_slice(&self.next_data_transfer_handle.to_le_bytes());
+        offset += 4;
+
+        buffer[offset] = self.transfer_flag;
+        offset += 1;
+
+        buffer[offset..offset + self.portion_of_device_metadata.len()]
+            .copy_from_slice(self.portion_of_device_metadata);
+
+        Ok(size)
+    }
+
+    fn decode(buffer: &'a [u8]) -> Result<Self, PldmCodecError> {
+        let size = core::mem::size_of::<Self>() - core::mem::size_of::<&'a [u8]>();
+        if buffer.len() < size {
+            return Err(PldmCodecError::BufferTooShort);
+        }
+
+        let mut offset = 0;
+
+        let hdr = PldmMsgHeader::read_from_prefix(&buffer[offset..])
+            .map_err(|_| PldmCodecError::BufferTooShort)?
+            .0;
+        offset += PLDM_MSG_HEADER_LEN;
+
+        let completion_code = buffer[offset];
+        offset += 1;
+
+        let next_data_transfer_handle = u32::from_le_bytes(
+            buffer[offset..offset + 4]
+                .try_into()
+                .map_err(|_| PldmCodecError::BufferTooShort)?,
+        );
+        offset += 4;
+
+        let transfer_flag = buffer[offset];
+        offset += 1;
+
+        let portion_of_device_metadata = &buffer[offset..];
+
+        Ok(Self {
+            hdr,
+            completion_code,
+            next_data_transfer_handle,
+            transfer_flag,
+            portion_of_device_metadata,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocol;
-
     use crate::codec::PldmCodec;
 
     #[test]
@@ -288,13 +454,15 @@ mod tests {
     }
 
     #[test]
-    fn test_get_data_response() {
+    fn test_get_package_data_response() {
+        const PORTION_LEN: usize = 10;
+
         let instance_id: InstanceId = 0x01;
         let next_data_transfer_handle: u32 = 0x12345678;
         let transfer_operation_flag = TransferOperationFlag::GetFirstPart;
-        let portion = [0u8; 0xff];
+        let portion = [22u8; PORTION_LEN];
 
-        let _ = GetPackageDataResponse::new(
+        let resp = GetPackageDataResponse::new(
             instance_id,
             GetPackageDataCode::BaseCodes(PldmBaseCompletionCode::Success),
             next_data_transfer_handle,
@@ -302,17 +470,53 @@ mod tests {
             &portion,
         );
 
-        //TODO: encoding for response does not work atm due to unknown sizes
-        // let mut buffer = [0u8; core::mem::size_of::<GetPackageDataResponse>()];
-        // request.encode(&mut buffer).unwrap();
-        // let decoded = GetPackageDataResponse::decode(&buffer).unwrap();
+        let mut buffer_fitted = [0u8; core::mem::size_of::<GetPackageDataResponse>()
+            - MAX_PORTION_DATA_SIZE
+            - core::mem::size_of::<usize>()
+            + PORTION_LEN];
 
-        // assert_eq!(request, decoded);
+        dbg!(&buffer_fitted.len());
+
+        resp.encode(&mut buffer_fitted).unwrap();
+        let decoded = GetPackageDataResponse::decode(&buffer_fitted).unwrap();
+        assert_eq!(resp, decoded);
     }
 
     #[test]
-    fn test_get_device_metadata_request() {}
+    fn test_get_device_metadata_request() {
+        let instance_id: InstanceId = 0x01;
+        let data_transfer_handle = 0x12345678;
+        let req = GetMetaDataRequest::new(
+            instance_id,
+            data_transfer_handle,
+            TransferOperationFlag::GetFirstPart,
+        );
+
+        let mut buffer = [0u8; core::mem::size_of::<GetMetaDataRequest>()];
+        req.encode(&mut buffer).unwrap();
+
+        let decoded = GetMetaDataRequest::decode(&buffer).unwrap();
+        assert_eq!(req, decoded);
+    }
 
     #[test]
-    fn test_get_device_metadata_reponse() {}
+    fn test_get_device_metadata_response() {
+        let instance_id: InstanceId = 0x01;
+        let data_transfer_handle = 0x12345678;
+        let payload = [11u8; 20];
+
+        let resp = GetMetaDataResponse::new(
+            instance_id,
+            GetMetaDataCode::BaseCodes(PldmBaseCompletionCode::Success),
+            data_transfer_handle,
+            TransferOperationFlag::GetFirstPart,
+            &payload,
+        );
+
+        let mut buffer = [0u8; 9 + 20];
+        resp.encode(&mut buffer).unwrap();
+
+        let decoded = GetMetaDataResponse::decode(&mut buffer).unwrap();
+        assert_eq!(resp, decoded);
+    }
 }

--- a/src/message/firmware_update/get_status.rs
+++ b/src/message/firmware_update/get_status.rs
@@ -189,7 +189,7 @@ mod test {
     use crate::codec::PldmCodec;
 
     #[test]
-    fn test_get_status_request() {
+    fn test_get_status_request_codec() {
         let instance_id = 1;
         let msg_type = PldmMsgType::Request;
         let request = GetStatusRequest::new(instance_id, msg_type);
@@ -202,7 +202,7 @@ mod test {
     }
 
     #[test]
-    fn test_get_status_response() {
+    fn test_get_status_response_codec() {
         let response = GetStatusResponse::new(
             1,
             0,

--- a/src/message/firmware_update/mod.rs
+++ b/src/message/firmware_update/mod.rs
@@ -3,6 +3,7 @@
 pub mod activate_fw;
 pub mod apply_complete;
 pub mod get_fw_params;
+pub mod get_package_data;
 pub mod get_status;
 pub mod pass_component;
 pub mod query_devid;

--- a/src/message/firmware_update/mod.rs
+++ b/src/message/firmware_update/mod.rs
@@ -6,6 +6,7 @@ pub mod get_fw_params;
 pub mod get_status;
 pub mod pass_component;
 pub mod query_devid;
+pub mod query_downstream;
 pub mod request_cancel;
 pub mod request_fw_data;
 pub mod request_update;

--- a/src/message/firmware_update/pass_component.rs
+++ b/src/message/firmware_update/pass_component.rs
@@ -154,7 +154,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_pass_component_table_request() {
+    fn test_pass_component_table_request_codec() {
         let request = PassComponentTableRequest::new(
             1,
             PldmMsgType::Request,
@@ -173,7 +173,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pass_component_table_response() {
+    fn test_pass_component_table_response_codec() {
         let response = PassComponentTableResponse::new(
             0,
             0,

--- a/src/message/firmware_update/query_devid.rs
+++ b/src/message/firmware_update/query_devid.rs
@@ -213,7 +213,6 @@ mod test {
     use super::*;
     use crate::protocol::firmware_update::{Descriptor, DescriptorType};
 
-    #[ignore]
     #[test]
     fn test_query_device_identifiers_resp_codec() {
         let instance_id = 0;

--- a/src/message/firmware_update/query_devid.rs
+++ b/src/message/firmware_update/query_devid.rs
@@ -213,8 +213,9 @@ mod test {
     use super::*;
     use crate::protocol::firmware_update::{Descriptor, DescriptorType};
 
+    #[ignore]
     #[test]
-    fn test_query_device_identifiers_resp() {
+    fn test_query_device_identifiers_resp_codec() {
         let instance_id = 0;
         let completion_code = 0;
 

--- a/src/message/firmware_update/query_downstream.rs
+++ b/src/message/firmware_update/query_downstream.rs
@@ -1,0 +1,311 @@
+// Licensed under the Apache-2.0 license
+
+use crate::protocol::base::{
+    InstanceId, PldmMsgHeader, PldmMsgType, PldmSupportedType, TransferOperationFlag,
+    PLDM_MSG_HEADER_LEN,
+};
+
+use crate::protocol::firmware_update::{Descriptor, FwUpdateCmd};
+use bitfield::bitfield;
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+/// QueryDownstreamDevices is used by the UA to obtain the firmware identifiers for the downstream devices supported
+/// by the FDP. The entire list of all attached downstream devices is provided by the response to
+/// QueryDownstreamIdentifiers command. The FDP shall provide a response message to this command in
+/// all states, including IDLE.
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[repr(C, packed)]
+pub struct QueryDownstreamDevicesRequest {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+}
+
+impl QueryDownstreamDevicesRequest {
+    pub fn new(instance_id: InstanceId) -> Self {
+        QueryDownstreamDevicesRequest {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Request,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::QueryDownstreamDevices as u8,
+            ),
+        }
+    }
+}
+
+bitfield! {
+    #[derive(Clone, Copy, FromBytes, IntoBytes, Immutable, PartialEq, Eq)]
+    pub struct QueryDownstreamDevicesCapability(u32);
+    impl Debug;
+    pub u32, reserved, _: 31, 3;
+    pub u32, update_simultaneous, set_update_simultaneous: 2;
+    pub u32, dynamic_remove, set_dynamic_remove: 1;
+    pub u32, dynamic_attach, set_dynamic_attach: 0;
+}
+
+#[derive(Debug, Clone, FromBytes, Immutable, PartialEq)]
+pub struct QueryDownstreamDeviceResponse {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+    // TODO: the spec also states to use enum8 here, so let's define some enums
+    pub completion_code: u8,
+    pub downstream_device_update_supported: u8,
+    pub number_of_downstream_devices: u16,
+    pub max_number_of_downstream_devices: u16,
+    pub capabilities: QueryDownstreamDevicesCapability,
+}
+
+impl QueryDownstreamDeviceResponse {
+    pub fn new(
+        instance_id: InstanceId,
+        completion_code: u8,
+        downstream_device_update_supported: u8,
+        number_of_downstream_devices: u16,
+        maximum_number_of_downstream_devices: u16,
+    ) -> Self {
+        QueryDownstreamDeviceResponse {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Response,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::QueryDownstreamDevices as u8,
+            ),
+            completion_code,
+            downstream_device_update_supported,
+            number_of_downstream_devices,
+            max_number_of_downstream_devices: maximum_number_of_downstream_devices,
+            capabilities: QueryDownstreamDevicesCapability(0),
+        }
+    }
+}
+
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[repr(C, packed)]
+pub struct QueryDownstreamIdentifiersRequest {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+    pub downstream_data_device_handle: u32,
+    pub transfer_op_flag: u8,
+}
+
+impl QueryDownstreamIdentifiersRequest {
+    pub fn new(
+        instance_id: InstanceId,
+        downstream_data_device_handle: u32,
+        transfer_op_flag: TransferOperationFlag,
+    ) -> Self {
+        QueryDownstreamIdentifiersRequest {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Request,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::QueryDownstreamIdentifiers as u8,
+            ),
+            downstream_data_device_handle,
+            transfer_op_flag: transfer_op_flag as u8,
+        }
+    }
+}
+
+// instead of using heapless::Vec, let's just allocate a fixed-size slices for now
+pub const DOWNSTREAM_DEVICE_PORTION_COUNT: usize = 4;
+pub const DOWNSTREAM_DEVICE_COUNT: usize = 8;
+pub const DOWNSTREAM_DESCRIPTOR_COUNT: usize = 4;
+
+// #[derive(Debug, Clone, Immutable, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C)]
+// TODO
+pub struct QueryDownstreamIdentifiersResponse {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+    pub completion_code: u8,
+    pub next_data_transfer_handle: u32,
+    pub transfer_flag: u8,
+
+    /// QueryDownstreamIdentifiersResponsePortion
+    ///
+    /// If the FDP has negotiated a PartSize as defined by DSP0240 and its NegotiateTransferParameters
+    /// command, then the maximum size for this field shall be equal to or less than that negotiated value.
+    /// Otherwise the FDP can determine the size for this field.
+    // TODO: check for PartSize and make this dynamic, for now make it static
+    pub portions: Option<[QueryDownstreamIdentifiersPortion; DOWNSTREAM_DEVICE_PORTION_COUNT]>,
+}
+
+impl QueryDownstreamIdentifiersResponse {
+    pub fn new(
+        instance_id: InstanceId,
+        completion_code: u8,
+        next_data_transfer_handle: u32,
+        transfer_flag: u8,
+        portions: Option<&[QueryDownstreamIdentifiersPortion; DOWNSTREAM_DEVICE_PORTION_COUNT]>,
+    ) -> Self {
+        let portions = portions.cloned();
+        QueryDownstreamIdentifiersResponse {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Response,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::QueryDownstreamIdentifiers as u8,
+            ),
+            completion_code,
+            next_data_transfer_handle,
+            transfer_flag,
+            portions,
+        }
+    }
+}
+
+// #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C)]
+pub struct QueryDownstreamIdentifiersPortion {
+    pub downstream_devices_length: u32,
+    pub number_of_downstream_devices: u16,
+    // pub first_downstream_device_index: DownstreamDeviceIndex,
+    pub first_downstream_device_index: u16,
+    pub downstream_devices: Option<[DownstreamDevices; DOWNSTREAM_DEVICE_COUNT]>,
+}
+
+impl QueryDownstreamIdentifiersPortion {
+    pub fn new(
+        downstream_devices_length: u32,
+        number_of_downstream_devices: u16,
+        // first_downstream_device_index: DownstreamDeviceIndex,
+        first_downstream_device_index: u16,
+        downstream_devices: Option<[DownstreamDevices; DOWNSTREAM_DEVICE_COUNT]>,
+    ) -> Self {
+        QueryDownstreamIdentifiersPortion {
+            downstream_devices_length,
+            number_of_downstream_devices,
+            first_downstream_device_index,
+            downstream_devices,
+        }
+    }
+}
+
+// #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+// pub enum DownstreamDeviceIndex {
+//     Index(u16), // 0x0000 – 0x0FFF = Downstream index number
+//     Reserved,   // 0x1000 – 0xFFFF = Reserved
+// }
+
+// impl From<u16> for DownstreamDeviceIndex {
+//     fn from(value: u16) -> Self {
+//         if value <= 0x0FFF {
+//             DownstreamDeviceIndex::Index(value)
+//         } else {
+//             DownstreamDeviceIndex::Reserved
+//         }
+//     }
+// }
+
+// #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C)]
+pub struct DownstreamDevices {
+    pub downstream_device_index: u16,
+    pub downstream_descriptor_count: u8,
+    pub downstream_descriptors: Option<[DownstreamDescriptor; DOWNSTREAM_DESCRIPTOR_COUNT]>,
+}
+
+impl DownstreamDevices {
+    pub fn new(
+        downstream_device_index: u16,
+        downstream_descriptor_count: u8,
+        downstream_descriptors: Option<[DownstreamDescriptor; DOWNSTREAM_DESCRIPTOR_COUNT]>,
+    ) -> Self {
+        DownstreamDevices {
+            downstream_device_index,
+            downstream_descriptor_count,
+            downstream_descriptors: downstream_descriptors.clone(),
+        }
+    }
+}
+
+// #[derive(Debug, Clone, FromBytes, IntoBytes, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C, packed)]
+pub struct DownstreamDescriptor {
+    pub descriptor_type: u8,
+    pub descriptor_length: u8,
+    pub descriptor_data: Descriptor,
+}
+
+impl DownstreamDescriptor {
+    pub fn new(descriptor_type: u8, descriptor_length: u8, descriptor_data: Descriptor) -> Self {
+        DownstreamDescriptor {
+            descriptor_type,
+            descriptor_length,
+            descriptor_data,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn test_query_device_identifier() {
+        let req = QueryDownstreamDevicesRequest::new(1);
+        assert_eq!(req.hdr.instance_id(), 1);
+    }
+
+    #[test]
+    fn test_query_downstream_device_response_new() {
+        let resp = QueryDownstreamDeviceResponse::new(2, 0x00, 0x01, 5, 10);
+        assert_eq!(resp.hdr.instance_id(), 2);
+        assert_eq!(resp.completion_code, 0x00);
+        assert_eq!(resp.downstream_device_update_supported, 0x01);
+        assert_eq!(resp.number_of_downstream_devices, 5);
+        assert_eq!(resp.max_number_of_downstream_devices, 10);
+        // capabilities default to zeroed fields
+        assert_eq!(resp.capabilities.update_simultaneous(), false);
+        assert_eq!(resp.capabilities.dynamic_remove(), false);
+        assert_eq!(resp.capabilities.dynamic_attach(), false);
+    }
+
+    #[test]
+    fn test_query_downstream_identifiers_portion_and_response() {
+        let portion = QueryDownstreamIdentifiersPortion::new(100u32, 2u16, 1u16, None);
+        let portions_arr = [
+            portion.clone(),
+            portion.clone(),
+            portion.clone(),
+            portion.clone(),
+        ];
+        let resp = QueryDownstreamIdentifiersResponse::new(4, 0x00, 0x1234, 1, Some(&portions_arr));
+        assert_eq!(resp.hdr.instance_id(), 4);
+        assert_eq!(resp.completion_code, 0x00);
+        assert_eq!(resp.next_data_transfer_handle, 0x1234);
+        assert_eq!(resp.transfer_flag, 1);
+        assert!(resp.portions.is_some());
+        let p = resp.portions.unwrap();
+        assert_eq!(p[0].downstream_devices_length, 100);
+        assert_eq!(p[0].number_of_downstream_devices, 2);
+        assert_eq!(p[0].first_downstream_device_index, 1);
+        assert!(p[0].downstream_devices.is_none());
+    }
+
+    #[test]
+    fn test_downstream_devices_new() {
+        let ds = DownstreamDevices::new(10u16, 0u8, None);
+        assert_eq!(ds.downstream_device_index, 10);
+        assert_eq!(ds.downstream_descriptor_count, 0);
+        assert!(ds.downstream_descriptors.is_none());
+    }
+
+    #[test]
+    fn test_query_downstream_identifiers_request_manual() {
+        let req = QueryDownstreamIdentifiersRequest {
+            hdr: PldmMsgHeader::new(
+                5,
+                PldmMsgType::Request,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::QueryDownstreamIdentifiers as u8,
+            ),
+            downstream_data_device_handle: 0xDEADBEEF,
+            transfer_op_flag: 0,
+        };
+        assert_eq!(req.hdr.instance_id(), 5);
+        let handle = req.downstream_data_device_handle;
+        assert_eq!(handle, 0xDEADBEEF);
+        assert_eq!(req.transfer_op_flag, 0);
+    }
+}

--- a/src/message/firmware_update/query_downstream.rs
+++ b/src/message/firmware_update/query_downstream.rs
@@ -184,7 +184,7 @@ struct PortionHeader {
     pub number_of_downstream_devices: u16,
 }
 
-#[derive(Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout, PartialEq, Eq)]
 #[repr(C, packed)]
 struct DownstreamDevicesHeader {
     pub downstream_devices_index: u16,
@@ -282,12 +282,13 @@ impl<'a> Iterator for QueryDownstreamIdentifiersResponse<'a> {
 
 impl<'a> PldmCodecWithLifetime<'a> for QueryDownstreamIdentifiersResponse<'a> {
     fn encode(&self, buffer: &mut [u8]) -> Result<usize, crate::codec::PldmCodecError> {
-        let max_size = size_of::<PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>>()
+        let size = size_of::<PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>>()
             + size_of::<u8>()
             + size_of::<u32>()
             + size_of::<u8>()
             + self.portion.len();
-        if buffer.len() < max_size {
+
+        if buffer.len() < size {
             return Err(crate::codec::PldmCodecError::BufferTooShort);
         }
 
@@ -307,42 +308,41 @@ impl<'a> PldmCodecWithLifetime<'a> for QueryDownstreamIdentifiersResponse<'a> {
 
         offset += size_of::<u8>();
         buffer[offset..offset + self.portion.len()].copy_from_slice(self.portion);
-        offset += self.portion.len();
 
-        Ok(offset)
+        Ok(offset + self.portion.len())
     }
 
-    fn decode(_buffer: &'a [u8]) -> Result<Self, crate::codec::PldmCodecError> {
+    fn decode(buffer: &'a [u8]) -> Result<Self, crate::codec::PldmCodecError> {
         let min_size = size_of::<PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>>()
             + size_of::<u8>()
             + size_of::<u32>()
             + size_of::<u8>();
 
-        if _buffer.len() < min_size {
+        if buffer.len() < min_size {
             return Err(crate::codec::PldmCodecError::BufferTooShort);
         }
 
         let mut offset = 0;
         let hdr = PldmMsgHeader::<[u8; PLDM_MSG_HEADER_LEN]>::read_from_bytes(
-            &_buffer[offset..offset + PLDM_MSG_HEADER_LEN],
+            &buffer[offset..offset + PLDM_MSG_HEADER_LEN],
         )
         .map_err(|_| crate::codec::PldmCodecError::BufferTooShort)?;
         offset += PLDM_MSG_HEADER_LEN;
 
-        let completion_code = _buffer[offset];
+        let completion_code = buffer[offset];
         offset += size_of::<u8>();
 
         let next_data_transfer_handle = u32::from_le_bytes(
-            _buffer[offset..offset + size_of::<u32>()]
+            buffer[offset..offset + size_of::<u32>()]
                 .try_into()
                 .map_err(|_| crate::codec::PldmCodecError::BufferTooShort)?,
         );
         offset += size_of::<u32>();
 
-        let transfer_flag = _buffer[offset];
+        let transfer_flag = buffer[offset];
         offset += size_of::<u8>();
 
-        let portion = &_buffer[offset..];
+        let portion = &buffer[offset..];
 
         Ok(QueryDownstreamIdentifiersResponse {
             hdr,
@@ -438,7 +438,6 @@ impl Iterator for DownstreamDevice<'_> {
         self._iter_offset += descriptor_size;
         self._iter_dev_count += 1;
 
-        // println!("{descriptor:?}");
         Some(descriptor)
     }
 }
@@ -885,18 +884,22 @@ impl PldmCodec for DownstreamDeviceParameterTable {
         let capabilities_during_update = CapabilitiesDuringUpdate::decode(&buffer[offset..])?;
         offset += size_of::<CapabilitiesDuringUpdate>();
 
-        let mut active_component_version_string = PldmFirmwareString::default();
-        active_component_version_string.str_type = active_component_version_string_type;
-        active_component_version_string.str_len = active_component_version_string_length;
+        let mut active_component_version_string = PldmFirmwareString {
+            str_type: active_component_version_string_type,
+            str_len: active_component_version_string_length,
+            str_data: [0u8; 32],
+        };
         active_component_version_string.str_data[..active_component_version_string_length as usize]
             .copy_from_slice(
                 &buffer[offset..offset + active_component_version_string_length as usize],
             );
         offset += active_component_version_string_length as usize;
 
-        let mut pending_component_version_string = PldmFirmwareString::default();
-        pending_component_version_string.str_type = pending_component_version_string_type;
-        pending_component_version_string.str_len = pending_component_version_string_length;
+        let mut pending_component_version_string = PldmFirmwareString {
+            str_type: pending_component_version_string_type,
+            str_len: pending_component_version_string_length,
+            str_data: [0u8; 32],
+        };
         pending_component_version_string.str_data
             [..pending_component_version_string_length as usize]
             .copy_from_slice(
@@ -948,9 +951,6 @@ impl PldmCodec for GetDownstreamFirmwareParametersResponse {
             + size_of::<u8>()
             + self.portion.size();
 
-        println!("DownstreamDeviceParameterTable encode size: {}", size);
-        println!("Buffer length: {}", buffer.len());
-
         if buffer.len() < size {
             return Err(crate::codec::PldmCodecError::BufferTooShort);
         }
@@ -972,9 +972,8 @@ impl PldmCodec for GetDownstreamFirmwareParametersResponse {
         offset += size_of::<u8>();
 
         let bytes_written = self.portion.encode(&mut buffer[offset..])?;
-        offset += bytes_written;
 
-        Ok(offset)
+        Ok(offset + bytes_written)
     }
 
     fn decode(buffer: &[u8]) -> Result<Self, crate::codec::PldmCodecError> {
@@ -1257,8 +1256,6 @@ mod tests {
                 + size_of::<ComponentActivationMethods>()
                 + size_of::<CapabilitiesDuringUpdate>();
 
-        dbg!(STR_DATA_OFFSET);
-
         let mut buffer = [0u8; STR_DATA_OFFSET + 4 + 4];
         let bytes_written = table.encode(&mut buffer).unwrap();
 
@@ -1292,8 +1289,6 @@ mod tests {
         )
         .unwrap();
 
-        dbg!(size_of_val(&downstream_device_parameter_table));
-
         let portion = GetDownstreamFirmwareParametersPortion {
             get_downstream_firmware_parameters_capability: FirmwareDeviceCapability(0u32),
             downstream_device_count: 1,
@@ -1310,7 +1305,6 @@ mod tests {
 
     #[test]
     fn test_get_downstream_firmware_parameters_response_codec() {
-        // todo!();
         let instance_id: InstanceId = 0x01;
         let downstream_device_index = DownstreamDeviceIndex::try_from(1).unwrap();
         let cap: FirmwareDeviceCapability = FirmwareDeviceCapability(0u32);
@@ -1469,11 +1463,14 @@ mod tests {
         let mut qdir_iter = qdir.next();
         let mut dsd_iter = qdir_iter.as_mut().unwrap().next();
         assert!(dsd_iter.is_some());
+        assert_eq!(dsc_0, dsd_iter.unwrap());
 
         dsd_iter = qdir_iter.as_mut().unwrap().next();
+        assert!(dsd_iter.is_some());
         assert_eq!(dsc_1, dsd_iter.unwrap());
 
         dsd_iter = qdir_iter.as_mut().unwrap().next();
+        assert!(dsd_iter.is_some());
         assert_eq!(dsc_2, dsd_iter.unwrap());
 
         qdir_iter = qdir.next();

--- a/src/message/firmware_update/query_downstream.rs
+++ b/src/message/firmware_update/query_downstream.rs
@@ -1,18 +1,23 @@
 // Licensed under the Apache-2.0 license
 
 use crate::protocol::base::{
-    InstanceId, PldmMsgHeader, PldmMsgType, PldmSupportedType, TransferOperationFlag,
-    PLDM_MSG_HEADER_LEN,
+    InstanceId, PldmBaseCompletionCode, PldmMsgHeader, PldmMsgType, PldmSupportedType,
+    TransferOperationFlag, PLDM_MSG_HEADER_LEN,
 };
 
-use crate::protocol::firmware_update::{ComponentActivationMethods, Descriptor, FwUpdateCmd};
+use crate::pldm_completion_code;
+
+use crate::protocol::firmware_update::{
+    ComponentActivationMethods, Descriptor, FwUpdateCmd, FwUpdateCompletionCode,
+};
 use bitfield::bitfield;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
-/// QueryDownstreamDevices is used by the UA to obtain the firmware identifiers for the downstream devices supported
-/// by the FDP. The entire list of all attached downstream devices is provided by the response to
-/// QueryDownstreamIdentifiers command. The FDP shall provide a response message to this command in
-/// all states, including IDLE.
+/// QueryDownstreamDevices is used by the UA to obtain the firmware identifiers
+/// for the downstream devices supported by the FDP. The entire list of all
+/// attached downstream devices is provided by the response to
+/// [QueryDownstreamIdentifiers] command. The FDP shall provide a response
+/// message to this command in all states, including IDLE.
 #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
 #[repr(C, packed)]
 pub struct QueryDownstreamDevicesRequest {
@@ -45,7 +50,8 @@ bitfield! {
 #[derive(Debug, Clone, FromBytes, Immutable, PartialEq)]
 pub struct QueryDownstreamDeviceResponse {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
-    // TODO: the spec also states to use enum8 here, so let's define some enums
+
+    /// PLDM_BASE_CODES
     pub completion_code: u8,
     pub downstream_device_update_supported: u8,
     pub number_of_downstream_devices: u16,
@@ -56,7 +62,7 @@ pub struct QueryDownstreamDeviceResponse {
 impl QueryDownstreamDeviceResponse {
     pub fn new(
         instance_id: InstanceId,
-        completion_code: u8,
+        completion_code: PldmBaseCompletionCode,
         downstream_device_update_supported: u8,
         number_of_downstream_devices: u16,
         maximum_number_of_downstream_devices: u16,
@@ -68,7 +74,7 @@ impl QueryDownstreamDeviceResponse {
                 PldmSupportedType::FwUpdate,
                 FwUpdateCmd::QueryDownstreamDevices as u8,
             ),
-            completion_code,
+            completion_code: completion_code as u8,
             downstream_device_update_supported,
             number_of_downstream_devices,
             max_number_of_downstream_devices: maximum_number_of_downstream_devices,
@@ -109,12 +115,23 @@ pub const DOWNSTREAM_DEVICE_PORTION_COUNT: usize = 4;
 pub const DOWNSTREAM_DEVICE_COUNT: usize = 8;
 pub const DOWNSTREAM_DESCRIPTOR_COUNT: usize = 4;
 
-// #[derive(Debug, Clone, Immutable, PartialEq)]
+pldm_completion_code! {
+    QueryDownstreamIdentifiersResponseCode {
+        InvalidTransferHandle,
+        InvalidTransferOperationFlag,
+        DownstreamDeviceListChanged,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
-// TODO
 pub struct QueryDownstreamIdentifiersResponse {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+
+    /// PLDM_BASE_CODES, INVALID_TRANSFER_HANDLE, INVALID_TRANSFER_OPERATION_FLAG,
+    /// DOWNSTREAM_DEVICE_LIST_CHANGED
+    ///
+    /// See [QueryDownstreamIdentifiersResponseCode].
     pub completion_code: u8,
     pub next_data_transfer_handle: u32,
     pub transfer_flag: u8,
@@ -131,7 +148,7 @@ pub struct QueryDownstreamIdentifiersResponse {
 impl QueryDownstreamIdentifiersResponse {
     pub fn new(
         instance_id: InstanceId,
-        completion_code: u8,
+        completion_code: QueryDownstreamIdentifiersResponseCode,
         next_data_transfer_handle: u32,
         transfer_flag: u8,
         portions: Option<&[QueryDownstreamIdentifiersPortion; DOWNSTREAM_DEVICE_PORTION_COUNT]>,
@@ -144,7 +161,7 @@ impl QueryDownstreamIdentifiersResponse {
                 PldmSupportedType::FwUpdate,
                 FwUpdateCmd::QueryDownstreamIdentifiers as u8,
             ),
-            completion_code,
+            completion_code: completion_code.into(),
             next_data_transfer_handle,
             transfer_flag,
             portions,
@@ -280,10 +297,23 @@ bitfield! {
     pub u32, downstream_device_component_update_failure, set_downstream_device_component_update_failure: 0;
 }
 
-// #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+pldm_completion_code! {
+    GetDownstreamFirmwareParametersResponseCode {
+        InvalidTransferHandle,
+        InvalidTransferOperationFlag,
+        DownstreamDeviceListChanged
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
+#[repr(C)]
 pub struct GetDownstreamFirmwareParametersResponse {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+
+    /// PLDM_BASE_CODES, INVALID_TRANSFER_HANDLE, INVALID_TRANSFER_OPERATION_FLAG,
+    /// DOWNSTREAM_DEVICE_LIST_CHANGED
+    ///
+    /// See [GetDownstreamFirmwareParametersResponseCode].
     pub completion_code: u8,
     pub next_data_transfer_handle: u32,
     pub transfer_flag: u8,
@@ -326,6 +356,29 @@ pub struct DownstreamDeviceParameterTable {
     // TODO: make this variable in length
     // "If no pending firmware component exists, this field is zero bytes in length"
     pub pending_component_version_string: Option<[u8; 0xff]>,
+}
+
+impl GetDownstreamFirmwareParametersResponse {
+    pub fn new(
+        instance_id: InstanceId,
+        completion_code: GetDownstreamFirmwareParametersResponseCode,
+        next_data_transfer_handle: u32,
+        transfer_flag: u8,
+        portions: Option<[GetDownstreamFirmwareParametersPortion; DOWNSTREAM_DEVICE_PORTION_COUNT]>,
+    ) -> Self {
+        GetDownstreamFirmwareParametersResponse {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Response,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::GetDownstreamFirmwareParameters as u8,
+            ),
+            completion_code: completion_code.into(),
+            next_data_transfer_handle,
+            transfer_flag,
+            portions,
+        }
+    }
 }
 
 bitfield! {
@@ -398,8 +451,21 @@ impl From<DDWillSendGetPackageDataCommand> for u8 {
     }
 }
 
+pldm_completion_code! {
+    RequestDownstreamDeviceUpdateCode {
+        AlreadyInUpdateMode,
+        UnableToInitiateUpdate,
+        RetryRequestUpdate
+    }
+}
+
 pub struct RequestDownstreamDeviceUpdateResponse {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+
+    /// PLDM_BASE_CODES, ALREADY_IN_UPDATE_MODE, UNABLE_TO_INITIATE_UPDATE,
+    /// RETRY_REQUEST_UPDATE
+    ///
+    /// See [RequestDownstreamDeviceUpdateCode].
     pub completion_code: u8,
     pub downstream_device_metadata_length: u16,
     pub pkg_data_command: u8,
@@ -409,7 +475,7 @@ pub struct RequestDownstreamDeviceUpdateResponse {
 impl RequestDownstreamDeviceUpdateResponse {
     pub fn new(
         instance_id: InstanceId,
-        completion_code: u8,
+        completion_code: RequestDownstreamDeviceUpdateCode,
         downstream_device_metadata_length: u16,
         pkg_data_command: DDWillSendGetPackageDataCommand,
         get_pkg_data_max_transfer_size: u16,
@@ -421,7 +487,7 @@ impl RequestDownstreamDeviceUpdateResponse {
                 PldmSupportedType::FwUpdate,
                 FwUpdateCmd::RequestDownstreamDeviceUpdate as u8,
             ),
-            completion_code,
+            completion_code: completion_code.into(),
             downstream_device_metadata_length,
             pkg_data_command: pkg_data_command.into(),
             get_pkg_data_max_transfer_size,
@@ -440,7 +506,8 @@ mod tests {
 
     #[test]
     fn test_query_downstream_device_response_new() {
-        let resp = QueryDownstreamDeviceResponse::new(2, 0x00, 0x01, 5, 10);
+        let resp =
+            QueryDownstreamDeviceResponse::new(2, PldmBaseCompletionCode::Success, 0x01, 5, 10);
         assert_eq!(resp.hdr.instance_id(), 2);
         assert_eq!(resp.completion_code, 0x00);
         assert_eq!(resp.downstream_device_update_supported, 0x01);
@@ -461,9 +528,21 @@ mod tests {
             portion.clone(),
             portion.clone(),
         ];
-        let resp = QueryDownstreamIdentifiersResponse::new(4, 0x00, 0x1234, 1, Some(&portions_arr));
+        let resp = QueryDownstreamIdentifiersResponse::new(
+            4,
+            QueryDownstreamIdentifiersResponseCode::BaseCodes(PldmBaseCompletionCode::Success),
+            0x1234,
+            1,
+            Some(&portions_arr),
+        );
+
         assert_eq!(resp.hdr.instance_id(), 4);
-        assert_eq!(resp.completion_code, 0x00);
+        assert_eq!(
+            QueryDownstreamIdentifiersResponseCode::BaseCodes(
+                PldmBaseCompletionCode::try_from(resp.completion_code).unwrap()
+            ),
+            QueryDownstreamIdentifiersResponseCode::BaseCodes(PldmBaseCompletionCode::Success),
+        );
         assert_eq!(resp.next_data_transfer_handle, 0x1234);
         assert_eq!(resp.transfer_flag, 1);
         assert!(resp.portions.is_some());

--- a/src/message/firmware_update/query_downstream.rs
+++ b/src/message/firmware_update/query_downstream.rs
@@ -47,7 +47,8 @@ bitfield! {
     pub u32, dynamic_attach, set_dynamic_attach: 0;
 }
 
-#[derive(Debug, Clone, FromBytes, Immutable, PartialEq)]
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[repr(C, packed)]
 pub struct QueryDownstreamDeviceResponse {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
 
@@ -498,102 +499,57 @@ impl RequestDownstreamDeviceUpdateResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::codec::PldmCodec;
+
     #[test]
-    fn test_query_device_identifier() {
-        let req = QueryDownstreamDevicesRequest::new(1);
-        assert_eq!(req.hdr.instance_id(), 1);
+    fn test_query_downstream_devices_request() {
+        let instance_id: InstanceId = 0x01;
+        let req = QueryDownstreamDevicesRequest::new(instance_id);
+
+        let mut buffer_encode = [0u8; core::mem::size_of::<QueryDownstreamDevicesRequest>()];
+        req.encode(&mut buffer_encode).unwrap();
+
+        let decoded = QueryDownstreamDevicesRequest::decode(&buffer_encode).unwrap();
+        assert_eq!(req, decoded);
     }
 
     #[test]
-    fn test_query_downstream_device_response_new() {
-        let resp =
-            QueryDownstreamDeviceResponse::new(2, PldmBaseCompletionCode::Success, 0x01, 5, 10);
-        assert_eq!(resp.hdr.instance_id(), 2);
-        assert_eq!(resp.completion_code, 0x00);
-        assert_eq!(resp.downstream_device_update_supported, 0x01);
-        assert_eq!(resp.number_of_downstream_devices, 5);
-        assert_eq!(resp.max_number_of_downstream_devices, 10);
-        // capabilities default to zeroed fields
-        assert_eq!(resp.capabilities.update_simultaneous(), false);
-        assert_eq!(resp.capabilities.dynamic_remove(), false);
-        assert_eq!(resp.capabilities.dynamic_attach(), false);
-    }
-
-    #[test]
-    fn test_query_downstream_identifiers_portion_and_response() {
-        let portion = QueryDownstreamIdentifiersPortion::new(100u32, 2u16, 1u16, None);
-        let portions_arr = [
-            portion.clone(),
-            portion.clone(),
-            portion.clone(),
-            portion.clone(),
-        ];
-        let resp = QueryDownstreamIdentifiersResponse::new(
-            4,
-            QueryDownstreamIdentifiersResponseCode::BaseCodes(PldmBaseCompletionCode::Success),
-            0x1234,
-            1,
-            Some(&portions_arr),
+    fn test_query_downstream_devices_response() {
+        let instance_id: InstanceId = 0x01;
+        let resp = QueryDownstreamDeviceResponse::new(
+            instance_id,
+            PldmBaseCompletionCode::Success,
+            1u8,
+            1u16,
+            1u16,
         );
 
-        assert_eq!(resp.hdr.instance_id(), 4);
-        assert_eq!(
-            QueryDownstreamIdentifiersResponseCode::BaseCodes(
-                PldmBaseCompletionCode::try_from(resp.completion_code).unwrap()
-            ),
-            QueryDownstreamIdentifiersResponseCode::BaseCodes(PldmBaseCompletionCode::Success),
+        let mut buffer_encode = [0u8; core::mem::size_of::<QueryDownstreamDeviceResponse>()];
+        resp.encode(&mut buffer_encode).unwrap();
+
+        let decoded = QueryDownstreamDeviceResponse::decode(&buffer_encode).unwrap();
+        assert_eq!(resp, decoded);
+    }
+
+    #[test]
+    fn query_downstream_identifiers_request() {
+        let instance_id: InstanceId = 0x01;
+        let downstream_data_device_handle = 0x12345678;
+        let transfer_op_flag = TransferOperationFlag::GetFirstPart;
+
+        let req = QueryDownstreamIdentifiersRequest::new(
+            instance_id,
+            downstream_data_device_handle,
+            transfer_op_flag,
         );
-        assert_eq!(resp.next_data_transfer_handle, 0x1234);
-        assert_eq!(resp.transfer_flag, 1);
-        assert!(resp.portions.is_some());
-        let p = resp.portions.unwrap();
-        assert_eq!(p[0].downstream_devices_length, 100);
-        assert_eq!(p[0].number_of_downstream_devices, 2);
-        assert_eq!(p[0].first_downstream_device_index, 1);
-        assert!(p[0].downstream_devices.is_none());
+
+        let mut buffer_encode = [0u8; core::mem::size_of::<QueryDownstreamIdentifiersRequest>()];
+        req.encode(&mut buffer_encode).unwrap();
+
+        let decoded = QueryDownstreamIdentifiersRequest::decode(&buffer_encode).unwrap();
+        assert_eq!(req, decoded);
     }
 
     #[test]
-    fn test_downstream_devices_new() {
-        let ds = DownstreamDevices::new(10u16, 0u8, None);
-        assert_eq!(ds.downstream_device_index, 10);
-        assert_eq!(ds.downstream_descriptor_count, 0);
-        assert!(ds.downstream_descriptors.is_none());
-    }
-
-    #[test]
-    fn test_get_downstream_firmware_parameters_request_manual() {
-        let req = GetDownstreamFirmwareParametersRequest {
-            hdr: PldmMsgHeader::new(
-                6,
-                PldmMsgType::Request,
-                PldmSupportedType::FwUpdate,
-                FwUpdateCmd::GetDownstreamFirmwareParameters as u8,
-            ),
-            data_transfer_handle: 0xAABBCCDD,
-            transfer_op_flag: 0,
-        };
-        assert_eq!(req.hdr.instance_id(), 6);
-        let handle = req.data_transfer_handle;
-        assert_eq!(handle, 0xAABBCCDD);
-        assert_eq!(req.transfer_op_flag, 0);
-    }
-
-    #[test]
-    fn test_query_downstream_identifiers_request_manual() {
-        let req = QueryDownstreamIdentifiersRequest {
-            hdr: PldmMsgHeader::new(
-                5,
-                PldmMsgType::Request,
-                PldmSupportedType::FwUpdate,
-                FwUpdateCmd::QueryDownstreamIdentifiers as u8,
-            ),
-            downstream_data_device_handle: 0xDEADBEEF,
-            transfer_op_flag: 0,
-        };
-        assert_eq!(req.hdr.instance_id(), 5);
-        let handle = req.downstream_data_device_handle;
-        assert_eq!(handle, 0xDEADBEEF);
-        assert_eq!(req.transfer_op_flag, 0);
-    }
+    fn query_downstream_identifiers_response() {}
 }

--- a/src/message/firmware_update/query_downstream.rs
+++ b/src/message/firmware_update/query_downstream.rs
@@ -129,6 +129,43 @@ pldm_completion_code! {
 
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
+/// The total structure for QueryDownstreamIdentifiersResponse looks as follows:
+/// ```text
+/// QueryDownstreamIdentifiersResponse
+///  completion_code (u8)
+///  next_data_transfer_handle (u32)
+///  transfer_flag (u8)
+///  --- portion (variable-length)
+///    downstream_devices_length_i (u32)
+///    number_of_downstream_devices_i (u16)
+///    downstream_devices_index_i (u16)
+///    ---
+///      downstream_device_index_ij (u16)
+///      downstream_descriptor_count_ij (u8)
+///      ---
+///        descriptor_type_ijk (u16)
+///        descriptor_length_ijk (u16)
+///        descriptor_data_ijk (variable-length L_ijk)
+///           ...
+///        descriptor_type_ij(k+1) (u16)
+///        descriptor_length_ij(k+1) (u16)
+///        descriptor_data_ij(k+1) (variable-length L_ij(k+1))
+///           ...
+///     ...
+///     downstream_devices_index_i(j+1) (u16)
+///     downstream_device_count_i(j+1) (u8)
+///     ---
+///       descriptor_type_(i(j+1)k) (u16)
+///       descriptor_length_(i(j+1)k) (u16)
+///       descriptor_data_(i(j+1)k) (variable-length L_(i(j+1)k))
+///         ...
+///      ...
+///    downstream_devices_length_(i+1) (u32)
+///    number_of_downstream_devices_(i+1) (u16)
+///    downstream_devices_index_(i+1) (u16)
+///    ...
+/// ...
+/// ```
 pub struct QueryDownstreamIdentifiersResponse<'a> {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
 
@@ -227,10 +264,10 @@ impl QueryDownstreamIdentifiersResponse<'_> {
     }
 }
 
-/// Iterate over all available [DownstreamDevice] in the response portion.
 impl<'a> Iterator for QueryDownstreamIdentifiersResponse<'a> {
     type Item = DownstreamDevice<'a>;
 
+    /// Iterate over all available [DownstreamDevice] in the response portion.
     fn next(&mut self) -> Option<Self::Item> {
         let portion_hdr = self.try_get_portion_header().ok()?;
         if self.portion_iter_current >= portion_hdr.number_of_downstream_devices as usize {
@@ -249,14 +286,18 @@ impl<'a> Iterator for QueryDownstreamIdentifiersResponse<'a> {
             return None;
         }
 
-        let hdr = self
+        let hdr: DownstreamDevicesHeader = self
             .try_get_downstream_device_header(&self.portion[offset..])
             .ok()?;
         let device_header_size = size_of::<DownstreamDevicesHeader>();
-        let descriptors_size = hdr.downstream_descriptor_count as usize * size_of::<Descriptor>();
-        let total_device_size = device_header_size + descriptors_size;
 
-        let next_offset = offset + total_device_size;
+        let desc_size = Descriptor::try_get_descriptor_length_from_blob(
+            &self.portion[offset + device_header_size..],
+            hdr.downstream_descriptor_count as usize,
+        )
+        .ok()?;
+
+        let next_offset = offset + device_header_size + desc_size;
         if next_offset > self.portion.len() {
             self.portion_iter_current = 0;
             self.portion_offset_next = 0;
@@ -423,19 +464,27 @@ impl Iterator for DownstreamDevice<'_> {
             return None;
         }
 
-        let descriptor_size = size_of::<Descriptor>();
-        if self.downstream_descriptors.len() < descriptor_size {
-            self._iter_dev_count = 0;
-            self._iter_offset = 0;
+        // Read the descriptor length while skipping the type field
+        let descriptor_length = u16::read_from_bytes(
+            &self.downstream_descriptors
+                [self._iter_offset + size_of::<u16>()..self._iter_offset + size_of::<u16>() * 2],
+        )
+        .ok()? as usize;
+
+        // check bounds
+        if self._iter_offset + size_of::<u16>() * 2 + descriptor_length
+            > self.downstream_descriptors.len()
+        {
             return None;
         }
 
-        let descriptor = Descriptor::try_read_from_prefix(
-            &self.downstream_descriptors[self._iter_offset..self._iter_offset + descriptor_size],
+        let descriptor = Descriptor::decode(
+            &self.downstream_descriptors
+                [self._iter_offset..self._iter_offset + 2 * size_of::<u16>() + descriptor_length],
         )
-        .ok()?
-        .0;
-        self._iter_offset += descriptor_size;
+        .ok()?;
+
+        self._iter_offset += size_of::<u16>() * 2 + descriptor_length;
         self._iter_dev_count += 1;
 
         Some(descriptor)
@@ -1141,7 +1190,7 @@ impl RequestDownstreamDeviceUpdateResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::codec::PldmCodec;
+    use crate::{codec::PldmCodec, protocol::firmware_update::DescriptorType};
 
     #[test]
     fn test_query_downstream_devices_request_codec() {
@@ -1389,15 +1438,18 @@ mod tests {
         let descriptors: [Descriptor; 3] = [descriptor.clone(), descriptor.clone(), descriptor];
 
         const DESC_LEN: usize = size_of::<Descriptor>();
-        let mut descriptor_bytes: [u8; DESC_LEN * 3] = [0u8; DESC_LEN * 3];
+        let mut descriptor_bytes_max: [u8; DESC_LEN * 3] = [0u8; DESC_LEN * 3];
         let mut offset = 0;
+
+        // encoding
         for desc in descriptors.iter() {
-            descriptor_bytes[offset..offset + DESC_LEN].copy_from_slice(&desc.as_bytes());
-            offset += DESC_LEN;
+            let encoded = desc.encode(&mut descriptor_bytes_max[offset..]).unwrap();
+            offset += encoded;
         }
 
         let downstream_device_index = DownstreamDeviceIndex::try_from(1).unwrap();
-        let downstream_device = DownstreamDevice::new(downstream_device_index, &descriptor_bytes);
+        let downstream_device =
+            DownstreamDevice::new(downstream_device_index, &descriptor_bytes_max);
 
         let mut buffer = [0u8; 256];
         let bytes_written = downstream_device.encode(&mut buffer).unwrap();
@@ -1407,6 +1459,7 @@ mod tests {
 
     #[test]
     fn test_iterator_query_downstream_identifiers_response() {
+        const DSC_DATA_LEN: usize = 16;
         let instance_id: InstanceId = 0x01;
         let ph: PortionHeader = PortionHeader {
             downstream_devices_length: 1,
@@ -1417,22 +1470,21 @@ mod tests {
             downstream_descriptor_count: 3,
         };
         let dsc_0: Descriptor = Descriptor {
-            descriptor_type: 0xff,
-            descriptor_length: 0x02,
+            descriptor_type: DescriptorType::VendorDefined as u16,
+            descriptor_length: DSC_DATA_LEN as u16,
             descriptor_data: [0u8; 64],
         };
 
         let mut dsc_1 = dsc_0.clone();
-        dsc_1.descriptor_type = 0xfe;
-        dsc_1.descriptor_data = [1u8; 64];
+        dsc_1.descriptor_data[0..16].clone_from_slice(&[1u8; 16]);
 
         let mut dsc_2 = dsc_0.clone();
-        dsc_2.descriptor_type = 0xfd;
-        dsc_2.descriptor_data = [2u8; 64];
+        dsc_2.descriptor_data[0..16].clone_from_slice(&[2u8; 16]);
 
         const LEN: usize = size_of::<PortionHeader>()
             + size_of::<DownstreamDevicesHeader>()
-            + 3 * size_of::<Descriptor>();
+            + 3 * (2 * size_of::<u16>() + DSC_DATA_LEN); // type + length + data
+
         let mut offset = 0;
         let mut portion: [u8; LEN] = [0u8; LEN];
 
@@ -1443,13 +1495,10 @@ mod tests {
             .copy_from_slice(&dsdh.as_bytes());
         offset += size_of::<DownstreamDevicesHeader>();
 
-        portion[offset..offset + size_of::<Descriptor>()].copy_from_slice(&dsc_0.as_bytes());
-        offset += size_of::<Descriptor>();
-
-        portion[offset..offset + size_of::<Descriptor>()].copy_from_slice(&dsc_1.as_bytes());
-        offset += size_of::<Descriptor>();
-
-        portion[offset..offset + size_of::<Descriptor>()].copy_from_slice(&dsc_2.as_bytes());
+        for desc in [dsc_0.clone(), dsc_1.clone(), dsc_2.clone()].iter() {
+            let size = &desc.encode(&mut portion[offset..]).unwrap();
+            offset += size;
+        }
 
         let mut qdir = QueryDownstreamIdentifiersResponse::new(
             instance_id,

--- a/src/message/firmware_update/query_downstream.rs
+++ b/src/message/firmware_update/query_downstream.rs
@@ -338,6 +338,96 @@ bitfield! {
     pub u32, downstream_updateable, set_downstream_updateable: 1;
     pub u32, downstream_apply_state, set_downstream_apply_state: 0;
 }
+// DMTF0267 12.17
+#[derive(Debug, Clone, FromBytes, Immutable, PartialEq)]
+pub struct RequestDownstreamDeviceUpdateRequest {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+    // "This value shall be equal to or greater than firmware update baseline transfer size"
+    // See section 7.8
+    pub max_downstream_device_transfer_size: u32,
+    pub max_outstanding_transfer_requests: u8,
+    pub downstream_device_pkg_data_length: u16,
+}
+
+impl RequestDownstreamDeviceUpdateRequest {
+    pub fn new(
+        instance_id: InstanceId,
+        max_downstream_device_transfer_size: u32,
+        max_outstanding_transfer_requests: u8,
+        downstream_device_pkg_data_length: u16,
+    ) -> Self {
+        RequestDownstreamDeviceUpdateRequest {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Request,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::RequestDownstreamDeviceUpdate as u8,
+            ),
+            max_downstream_device_transfer_size,
+            max_outstanding_transfer_requests,
+            downstream_device_pkg_data_length,
+        }
+    }
+}
+
+pub enum DDWillSendGetPackageDataCommand {
+    FDPShouldObtainUALimited = 0x02,
+    FDPShouldObtainLearn = 0x01,
+    FDPNoSupport = 0x00,
+}
+
+impl TryFrom<u8> for DDWillSendGetPackageDataCommand {
+    type Error = ();
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x02 => Ok(DDWillSendGetPackageDataCommand::FDPShouldObtainUALimited),
+            0x01 => Ok(DDWillSendGetPackageDataCommand::FDPShouldObtainLearn),
+            0x00 => Ok(DDWillSendGetPackageDataCommand::FDPNoSupport),
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<DDWillSendGetPackageDataCommand> for u8 {
+    fn from(cmd: DDWillSendGetPackageDataCommand) -> Self {
+        match cmd {
+            DDWillSendGetPackageDataCommand::FDPShouldObtainUALimited => 0x02,
+            DDWillSendGetPackageDataCommand::FDPShouldObtainLearn => 0x01,
+            DDWillSendGetPackageDataCommand::FDPNoSupport => 0x00,
+        }
+    }
+}
+
+pub struct RequestDownstreamDeviceUpdateResponse {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+    pub completion_code: u8,
+    pub downstream_device_metadata_length: u16,
+    pub pkg_data_command: u8,
+    pub get_pkg_data_max_transfer_size: u16,
+}
+
+impl RequestDownstreamDeviceUpdateResponse {
+    pub fn new(
+        instance_id: InstanceId,
+        completion_code: u8,
+        downstream_device_metadata_length: u16,
+        pkg_data_command: DDWillSendGetPackageDataCommand,
+        get_pkg_data_max_transfer_size: u16,
+    ) -> Self {
+        RequestDownstreamDeviceUpdateResponse {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Response,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::RequestDownstreamDeviceUpdate as u8,
+            ),
+            completion_code,
+            downstream_device_metadata_length,
+            pkg_data_command: pkg_data_command.into(),
+            get_pkg_data_max_transfer_size,
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/message/firmware_update/query_downstream.rs
+++ b/src/message/firmware_update/query_downstream.rs
@@ -1,5 +1,7 @@
 // Licensed under the Apache-2.0 license
 
+use crate::codec::{PldmCodec, PldmCodecError, PldmCodecWithLifetime};
+use crate::error::PldmError;
 use crate::protocol::base::{
     InstanceId, PldmBaseCompletionCode, PldmMsgHeader, PldmMsgType, PldmSupportedType,
     TransferOperationFlag, PLDM_MSG_HEADER_LEN,
@@ -8,10 +10,11 @@ use crate::protocol::base::{
 use crate::pldm_completion_code;
 
 use crate::protocol::firmware_update::{
-    ComponentActivationMethods, Descriptor, FwUpdateCmd, FwUpdateCompletionCode,
+    ComponentActivationMethods, Descriptor, FirmwareDeviceCapability, FwUpdateCmd,
+    FwUpdateCompletionCode, PldmFirmwareString,
 };
 use bitfield::bitfield;
-use zerocopy::{FromBytes, Immutable, IntoBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout, TryFromBytes};
 
 /// QueryDownstreamDevices is used by the UA to obtain the firmware identifiers
 /// for the downstream devices supported by the FDP. The entire list of all
@@ -126,7 +129,7 @@ pldm_completion_code! {
 
 #[derive(Debug, Clone, PartialEq)]
 #[repr(C)]
-pub struct QueryDownstreamIdentifiersResponse {
+pub struct QueryDownstreamIdentifiersResponse<'a> {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
 
     /// PLDM_BASE_CODES, INVALID_TRANSFER_HANDLE, INVALID_TRANSFER_OPERATION_FLAG,
@@ -143,18 +146,20 @@ pub struct QueryDownstreamIdentifiersResponse {
     /// command, then the maximum size for this field shall be equal to or less than that negotiated value.
     /// Otherwise the FDP can determine the size for this field.
     // TODO: check for PartSize and make this dynamic, for now make it static
-    pub portions: Option<[QueryDownstreamIdentifiersPortion; DOWNSTREAM_DEVICE_PORTION_COUNT]>,
+    // pub portions: &'a QueryDownstreamIdentifiersPortion<'a>,
+    pub portion: &'a [u8],
+    portion_iter_current: usize,
+    portion_offset_next: usize,
 }
 
-impl QueryDownstreamIdentifiersResponse {
+impl<'a> QueryDownstreamIdentifiersResponse<'a> {
     pub fn new(
         instance_id: InstanceId,
         completion_code: QueryDownstreamIdentifiersResponseCode,
         next_data_transfer_handle: u32,
         transfer_flag: u8,
-        portions: Option<&[QueryDownstreamIdentifiersPortion; DOWNSTREAM_DEVICE_PORTION_COUNT]>,
+        portion: &'a [u8],
     ) -> Self {
-        let portions = portions.cloned();
         QueryDownstreamIdentifiersResponse {
             hdr: PldmMsgHeader::new(
                 instance_id,
@@ -165,99 +170,338 @@ impl QueryDownstreamIdentifiersResponse {
             completion_code: completion_code.into(),
             next_data_transfer_handle,
             transfer_flag,
-            portions,
+            portion,
+            portion_iter_current: 0,
+            portion_offset_next: 0,
         }
     }
 }
 
-// #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
-#[derive(Debug, Clone, PartialEq)]
-#[repr(C)]
-pub struct QueryDownstreamIdentifiersPortion {
+#[derive(Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+#[repr(C, packed)]
+struct PortionHeader {
     pub downstream_devices_length: u32,
     pub number_of_downstream_devices: u16,
-    // pub first_downstream_device_index: DownstreamDeviceIndex,
-    pub first_downstream_device_index: u16,
-    pub downstream_devices: Option<[DownstreamDevices; DOWNSTREAM_DEVICE_COUNT]>,
 }
 
-impl QueryDownstreamIdentifiersPortion {
-    pub fn new(
-        downstream_devices_length: u32,
-        number_of_downstream_devices: u16,
-        // first_downstream_device_index: DownstreamDeviceIndex,
-        first_downstream_device_index: u16,
-        downstream_devices: Option<[DownstreamDevices; DOWNSTREAM_DEVICE_COUNT]>,
-    ) -> Self {
-        QueryDownstreamIdentifiersPortion {
-            downstream_devices_length,
-            number_of_downstream_devices,
-            first_downstream_device_index,
-            downstream_devices,
+#[derive(Debug, TryFromBytes, IntoBytes, Immutable, KnownLayout)]
+#[repr(C, packed)]
+struct DownstreamDevicesHeader {
+    pub downstream_devices_index: u16,
+    pub downstream_descriptor_count: u8,
+}
+
+// Idea: use get, at(i), try_at(i) and iterator to get elements dynamically from portions buffer
+impl QueryDownstreamIdentifiersResponse<'_> {
+    /// Parse the portions slice and get the header information.
+    ///
+    /// Returns an error of the slice is too small and the parsing failed.
+    fn try_get_portion_header(&mut self) -> Result<PortionHeader, PldmError> {
+        Ok(PortionHeader::try_read_from_prefix(self.portion)
+            .map_err(|_| PldmError::InvalidData)?
+            .0)
+    }
+
+    /// Try to get a [DownstreamDevicesHeader] from the given slice index.
+    ///
+    /// Returns an error if the slice is too small or the parsing failed.
+    fn try_get_downstream_device_header(
+        &self,
+        buf: &[u8],
+    ) -> Result<DownstreamDevicesHeader, PldmError> {
+        Ok(DownstreamDevicesHeader::try_read_from_prefix(buf)
+            .map_err(|_| PldmError::InvalidData)?
+            .0)
+    }
+
+    /// Try to get a [DownstreamDevice] at a given index in the portion.
+    ///
+    /// If the index is out of range, return an [PldmError].
+    pub fn try_at(&self, index: usize) -> Result<DownstreamDevice<'_>, PldmError> {
+        for (device_index, device) in self.clone().enumerate() {
+            if device_index == index {
+                return Ok(device);
+            }
+        }
+        Err(PldmError::InvalidData)
+    }
+}
+
+/// Iterate over all available [DownstreamDevice] in the response portion.
+impl<'a> Iterator for QueryDownstreamIdentifiersResponse<'a> {
+    type Item = DownstreamDevice<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let portion_hdr = self.try_get_portion_header().ok()?;
+        if self.portion_iter_current >= portion_hdr.number_of_downstream_devices as usize {
+            // at the end, let's reset for next iteration
+            self.portion_iter_current = 0;
+            self.portion_offset_next = 0;
+            return None;
+        }
+
+        let offset = if self.portion_iter_current == 0 {
+            size_of::<PortionHeader>()
+        } else {
+            self.portion_offset_next
+        };
+        if offset >= self.portion.len() {
+            return None;
+        }
+
+        let hdr = self
+            .try_get_downstream_device_header(&self.portion[offset..])
+            .ok()?;
+        let device_header_size = size_of::<DownstreamDevicesHeader>();
+        let descriptors_size = hdr.downstream_descriptor_count as usize * size_of::<Descriptor>();
+        let total_device_size = device_header_size + descriptors_size;
+
+        let next_offset = offset + total_device_size;
+        if next_offset > self.portion.len() {
+            self.portion_iter_current = 0;
+            self.portion_offset_next = 0;
+            return None;
+        }
+
+        let descriptor_start = offset + device_header_size;
+        let descriptor_end = next_offset;
+
+        self.portion_offset_next = next_offset;
+        self.portion_iter_current += 1;
+
+        let device = DownstreamDevice {
+            downstream_device_index: hdr.downstream_devices_index,
+            downstream_descriptor_count: hdr.downstream_descriptor_count,
+            downstream_descriptors: &self.portion[descriptor_start..descriptor_end],
+            _iter_dev_count: 0,
+            _iter_offset: 0,
+        };
+        Some(device)
+    }
+}
+
+impl<'a> PldmCodecWithLifetime<'a> for QueryDownstreamIdentifiersResponse<'a> {
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, crate::codec::PldmCodecError> {
+        let max_size = size_of::<PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>>()
+            + size_of::<u8>()
+            + size_of::<u32>()
+            + size_of::<u8>()
+            + self.portion.len();
+        if buffer.len() < max_size {
+            return Err(crate::codec::PldmCodecError::BufferTooShort);
+        }
+
+        let mut offset = 0;
+        self.hdr
+            .write_to(&mut buffer[offset..offset + PLDM_MSG_HEADER_LEN])
+            .map_err(|_| crate::codec::PldmCodecError::BufferTooShort)?;
+        offset += PLDM_MSG_HEADER_LEN;
+
+        buffer[offset] = self.completion_code;
+        offset += size_of::<u8>();
+        buffer[offset..offset + size_of::<u32>()]
+            .copy_from_slice(&self.next_data_transfer_handle.to_le_bytes());
+
+        offset += size_of::<u32>();
+        buffer[offset] = self.transfer_flag;
+
+        offset += size_of::<u8>();
+        buffer[offset..offset + self.portion.len()].copy_from_slice(self.portion);
+        offset += self.portion.len();
+
+        Ok(offset)
+    }
+
+    fn decode(_buffer: &'a [u8]) -> Result<Self, crate::codec::PldmCodecError> {
+        let min_size = size_of::<PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>>()
+            + size_of::<u8>()
+            + size_of::<u32>()
+            + size_of::<u8>();
+
+        if _buffer.len() < min_size {
+            return Err(crate::codec::PldmCodecError::BufferTooShort);
+        }
+
+        let mut offset = 0;
+        let hdr = PldmMsgHeader::<[u8; PLDM_MSG_HEADER_LEN]>::read_from_bytes(
+            &_buffer[offset..offset + PLDM_MSG_HEADER_LEN],
+        )
+        .map_err(|_| crate::codec::PldmCodecError::BufferTooShort)?;
+        offset += PLDM_MSG_HEADER_LEN;
+
+        let completion_code = _buffer[offset];
+        offset += size_of::<u8>();
+
+        let next_data_transfer_handle = u32::from_le_bytes(
+            _buffer[offset..offset + size_of::<u32>()]
+                .try_into()
+                .map_err(|_| crate::codec::PldmCodecError::BufferTooShort)?,
+        );
+        offset += size_of::<u32>();
+
+        let transfer_flag = _buffer[offset];
+        offset += size_of::<u8>();
+
+        let portion = &_buffer[offset..];
+
+        Ok(QueryDownstreamIdentifiersResponse {
+            hdr,
+            completion_code,
+            next_data_transfer_handle,
+            transfer_flag,
+            portion,
+            portion_offset_next: 0,
+            portion_iter_current: 0,
+        })
+    }
+}
+
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+pub struct DownstreamDeviceIndex(u16);
+
+#[allow(unused)]
+impl DownstreamDeviceIndex {
+    /// 0x0000 – 0x0FFF = Downstream index number
+    const FIRST_RESERVED: DownstreamDeviceIndex = DownstreamDeviceIndex(0x1000);
+
+    /// 0x1000 – 0xFFFF = Reserved
+    const LAST_RESERVED: DownstreamDeviceIndex = DownstreamDeviceIndex(0xFFFF);
+}
+
+impl TryFrom<u16> for DownstreamDeviceIndex {
+    type Error = ();
+
+    /// Create a valid DownstreamDeviceIndex from a u16 value.
+    /// See [DownstreamDeviceIndex] with FIRST_RESERVED and LAST_RESERVED.
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        if value < Self::FIRST_RESERVED.0 {
+            Ok(DownstreamDeviceIndex(value))
+        } else {
+            Err(())
         }
     }
 }
 
-// #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
-// pub enum DownstreamDeviceIndex {
-//     Index(u16), // 0x0000 – 0x0FFF = Downstream index number
-//     Reserved,   // 0x1000 – 0xFFFF = Reserved
-// }
-
-// impl From<u16> for DownstreamDeviceIndex {
-//     fn from(value: u16) -> Self {
-//         if value <= 0x0FFF {
-//             DownstreamDeviceIndex::Index(value)
-//         } else {
-//             DownstreamDeviceIndex::Reserved
-//         }
-//     }
-// }
-
-// #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Default, FromBytes)]
 #[repr(C)]
-pub struct DownstreamDevices {
+pub struct DownstreamDevice<'a> {
     pub downstream_device_index: u16,
     pub downstream_descriptor_count: u8,
-    pub downstream_descriptors: Option<[DownstreamDescriptor; DOWNSTREAM_DESCRIPTOR_COUNT]>,
+    pub downstream_descriptors: &'a [u8],
+
+    // Iterator state, ignore for parsing!!
+    _iter_dev_count: usize,
+    _iter_offset: usize,
 }
 
-impl DownstreamDevices {
+impl<'a> DownstreamDevice<'a> {
     pub fn new(
-        downstream_device_index: u16,
-        downstream_descriptor_count: u8,
-        downstream_descriptors: Option<[DownstreamDescriptor; DOWNSTREAM_DESCRIPTOR_COUNT]>,
+        downstream_device_index: DownstreamDeviceIndex,
+        downstream_descriptors: &'a [u8],
     ) -> Self {
-        DownstreamDevices {
+        DownstreamDevice {
+            downstream_device_index: downstream_device_index.0,
+            downstream_descriptor_count: downstream_descriptors.len() as u8,
+            downstream_descriptors,
+            _iter_dev_count: 0,
+            _iter_offset: 0,
+        }
+    }
+}
+
+impl Iterator for DownstreamDevice<'_> {
+    type Item = Descriptor;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.downstream_descriptor_count == 0 {
+            return None;
+        }
+
+        if self._iter_dev_count >= self.downstream_descriptor_count as usize {
+            self._iter_dev_count = 0;
+            self._iter_offset = 0;
+            return None;
+        }
+
+        let descriptor_size = size_of::<Descriptor>();
+        if self.downstream_descriptors.len() < descriptor_size {
+            self._iter_dev_count = 0;
+            self._iter_offset = 0;
+            return None;
+        }
+
+        let descriptor = Descriptor::try_read_from_prefix(
+            &self.downstream_descriptors[self._iter_offset..self._iter_offset + descriptor_size],
+        )
+        .ok()?
+        .0;
+        self._iter_offset += descriptor_size;
+        self._iter_dev_count += 1;
+
+        // println!("{descriptor:?}");
+        Some(descriptor)
+    }
+}
+
+impl<'a> PldmCodecWithLifetime<'a> for DownstreamDevice<'a> {
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, crate::codec::PldmCodecError> {
+        let mut offset = 0;
+        let size = size_of::<DownstreamDeviceIndex>()
+            + size_of::<u8>()
+            + self
+                .downstream_descriptors
+                .iter()
+                .map(|d| d.encode(&mut []).unwrap_or(0))
+                .sum::<usize>();
+
+        if buffer.len() < size {
+            return Err(crate::codec::PldmCodecError::BufferTooShort);
+        }
+
+        buffer[offset..offset + size_of::<DownstreamDeviceIndex>()]
+            .copy_from_slice(&self.downstream_device_index.to_le_bytes());
+        offset += size_of::<DownstreamDeviceIndex>();
+
+        buffer[offset] = self.downstream_descriptor_count;
+        offset += 1;
+
+        for descriptor in self.downstream_descriptors.iter() {
+            let bytes_written = descriptor.encode(&mut buffer[offset..])?;
+            offset += bytes_written;
+        }
+        Ok(offset)
+    }
+
+    fn decode(buffer: &'a [u8]) -> Result<Self, crate::codec::PldmCodecError> {
+        // min size: DownstreamDeviceIndex + descriptor count(0)
+        let min_size = size_of::<DownstreamDeviceIndex>() + size_of::<u8>();
+        let mut offset = 0;
+
+        if buffer.len() < min_size {
+            return Err(crate::codec::PldmCodecError::BufferTooShort);
+        }
+
+        let downstream_device_index = u16::from_le_bytes(
+            buffer[offset..offset + size_of::<u16>()]
+                .try_into()
+                .map_err(|_| crate::codec::PldmCodecError::BufferTooShort)?,
+        );
+        offset += size_of::<u16>();
+
+        let downstream_descriptor_count = buffer[offset];
+        offset += 1;
+
+        Ok(Self {
             downstream_device_index,
             downstream_descriptor_count,
-            downstream_descriptors: downstream_descriptors.clone(),
-        }
+            downstream_descriptors: &buffer[offset..],
+            _iter_dev_count: 0,
+            _iter_offset: 0,
+        })
     }
 }
 
-// #[derive(Debug, Clone, FromBytes, IntoBytes, PartialEq)]
-#[derive(Debug, Clone, PartialEq)]
-#[repr(C, packed)]
-pub struct DownstreamDescriptor {
-    pub descriptor_type: u8,
-    pub descriptor_length: u8,
-    pub descriptor_data: Descriptor,
-}
-
-impl DownstreamDescriptor {
-    pub fn new(descriptor_type: u8, descriptor_length: u8, descriptor_data: Descriptor) -> Self {
-        DownstreamDescriptor {
-            descriptor_type,
-            descriptor_length,
-            descriptor_data,
-        }
-    }
-}
-
-// #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
 #[repr(C, packed)]
 pub struct GetDownstreamFirmwareParametersRequest {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
@@ -284,20 +528,6 @@ impl GetDownstreamFirmwareParametersRequest {
     }
 }
 
-bitfield! {
-    #[derive(Clone, Copy, FromBytes, IntoBytes, Immutable, PartialEq, Eq)]
-    pub struct GetDownstreamFirmwareParametersCapability(u32);
-    impl Debug;
-    pub u32, reserved_0, _: 31, 10;
-    pub u32, secuirty_revision_number, set_secuirty_revision_number: 9;
-    pub u32, fdp_downgrade_restrictions, set_fdp_downgrade_restrictions: 8;
-    pub u32, fdp_update_mode_restrictions, set_fdp_update_mode_restrictions: 7, 4;
-    pub u32, reserved_1, _: 3;
-    pub u32, downstream_device_host_functionality, set_downstream_device_host_functionality: 2;
-    pub u32, component_update_failure_retry, set_component_update_failure_retry: 1;
-    pub u32, downstream_device_component_update_failure, set_downstream_device_component_update_failure: 0;
-}
-
 pldm_completion_code! {
     GetDownstreamFirmwareParametersResponseCode {
         InvalidTransferHandle,
@@ -306,7 +536,7 @@ pldm_completion_code! {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, FromBytes)]
 #[repr(C)]
 pub struct GetDownstreamFirmwareParametersResponse {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
@@ -325,38 +555,366 @@ pub struct GetDownstreamFirmwareParametersResponse {
     /// command, then the maximum size for this field shall be equal to or less than that negotiated value.
     /// Otherwise the FDP can determine the size for this field.
     // TODO: check for PartSize and make this dynamic
-    pub portions: Option<[GetDownstreamFirmwareParametersPortion; DOWNSTREAM_DEVICE_PORTION_COUNT]>,
+    pub portion: GetDownstreamFirmwareParametersPortion,
 }
 
 // #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, FromBytes)]
 #[repr(C)]
 pub struct GetDownstreamFirmwareParametersPortion {
-    pub get_downstream_firmware_parameters_capability: GetDownstreamFirmwareParametersCapability,
+    pub get_downstream_firmware_parameters_capability: FirmwareDeviceCapability,
     pub downstream_device_count: u16,
-    pub downstream_device_parameter_table: Option<[DownstreamDeviceParameterTable; 8]>,
+    pub downstream_device_parameter_table: DownstreamDeviceParameterTable,
 }
 
-#[derive(Debug, Clone, PartialEq)]
-#[repr(C)]
+impl GetDownstreamFirmwareParametersPortion {
+    pub fn new(
+        capability: FirmwareDeviceCapability,
+        downstream_device_count: u16,
+        downstream_device_parameter_table: DownstreamDeviceParameterTable,
+    ) -> Self {
+        GetDownstreamFirmwareParametersPortion {
+            get_downstream_firmware_parameters_capability: capability,
+            downstream_device_count,
+            downstream_device_parameter_table,
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        size_of::<FirmwareDeviceCapability>()
+            + size_of::<u16>()
+            + self.downstream_device_parameter_table.size()
+    }
+}
+
+impl PldmCodec for GetDownstreamFirmwareParametersPortion {
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, crate::codec::PldmCodecError> {
+        if buffer.len() < self.size() {
+            return Err(crate::codec::PldmCodecError::BufferTooShort);
+        }
+
+        let mut offset = 0;
+        buffer[offset..offset + size_of::<FirmwareDeviceCapability>()].copy_from_slice(
+            &self
+                .get_downstream_firmware_parameters_capability
+                .0
+                .to_le_bytes(),
+        );
+        offset += size_of::<FirmwareDeviceCapability>();
+
+        buffer[offset..offset + size_of::<u16>()]
+            .copy_from_slice(&self.downstream_device_count.to_le_bytes());
+        offset += size_of::<u16>();
+
+        let bytes_written = self
+            .downstream_device_parameter_table
+            .encode(&mut buffer[offset..])?;
+
+        Ok(offset + bytes_written)
+    }
+
+    fn decode(buffer: &[u8]) -> Result<Self, crate::codec::PldmCodecError> {
+        let min_size = size_of::<FirmwareDeviceCapability>() + size_of::<u16>();
+        let mut offset = 0;
+
+        if buffer.len() < min_size {
+            return Err(crate::codec::PldmCodecError::BufferTooShort);
+        }
+
+        let capability = u32::from_le_bytes(
+            buffer[offset..offset + size_of::<u32>()]
+                .try_into()
+                .map_err(|_| crate::codec::PldmCodecError::InvalidData)?,
+        );
+        offset += size_of::<u32>();
+
+        let downstream_device_count = u16::from_le_bytes(
+            buffer[offset..offset + size_of::<u16>()]
+                .try_into()
+                .map_err(|_| crate::codec::PldmCodecError::InvalidData)?,
+        );
+        offset += size_of::<u16>();
+
+        let downstream_device_parameter_table =
+            DownstreamDeviceParameterTable::decode(&buffer[offset..])?;
+
+        Ok(GetDownstreamFirmwareParametersPortion {
+            get_downstream_firmware_parameters_capability: FirmwareDeviceCapability(capability),
+            downstream_device_count,
+            downstream_device_parameter_table,
+        })
+    }
+}
+
+/// Wrapper struct for PLDM timestamp representation
+#[derive(Debug, Clone, Copy, PartialEq, FromBytes, IntoBytes)]
+#[repr(C, packed)]
+pub struct PldmTimeStamp([u8; 8]);
+
+impl PldmTimeStamp {
+    /// Ensure that only valid timestamps are created
+    /// The timestamp string must be in the format "YYYYMMDD", where Y is year, M is month, D is day.
+    /// These are ASCII characters in range 0x30 to 0x39, which are the ascii digits '0' to '9'.
+    pub fn new(timestamp: &str) -> Result<Self, PldmError> {
+        if timestamp.len() != 8 {
+            return Err(PldmError::InvalidData);
+        }
+
+        let ts_bytes: [u8; 8] = timestamp
+            .as_bytes()
+            .try_into()
+            .map_err(|_| PldmError::InvalidData)?;
+
+        ts_bytes.iter().try_for_each(|&b| {
+            if !(0x30..=0x39).contains(&b) {
+                Err(PldmError::InvalidData)
+            } else {
+                Ok(())
+            }
+        })?;
+        Ok(PldmTimeStamp(ts_bytes))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, FromBytes, IntoBytes)]
+#[repr(C, packed)]
+/// # Warning
+/// This struct is not a 1:1 representation of the PLDM spec,
+/// since for simplicity we want to use PldmFirmwareString for the version strings.
+/// This decision was made to prioritize usability over strict adherence to the spec.
+/// For the original, see [DSP0267](https://www.dmtf.org/sites/default/files/standards/documents/DSP0267_1.2.0WIP99.pdf), Table 21.
+///
+/// It is up for discussion whether this is the right approach. For now we proceed with this.
 pub struct DownstreamDeviceParameterTable {
     pub downstream_device_index: u16,
     pub active_component_comparison_stamp: u32,
-    pub active_component_version_string_type: u8, // See VersionStringType
-    pub active_component_version_string_length: u8,
-    pub active_component_release_date: [u8; 8], // YYYYMMDD
+    // pub active_component_version_string_type: u8, // See VersionStringType
+    // pub active_component_version_string_length: u8,
+    pub active_component_release_date: PldmTimeStamp,
     pub pending_component_comparison_stamp: u32,
-    pub pending_component_version_string_type: u8, // See VersionStringType
-    pub pending_component_version_string_length: u8,
-    pub pending_component_release_date: [u8; 8], // YYYYMMDD
+    // pub pending_component_version_string_type: u8, // See VersionStringType
+    // pub pending_component_version_string_length: u8,
+    pub pending_component_release_date: PldmTimeStamp,
     pub component_activation_methods: ComponentActivationMethods,
+    pub capabilities_during_update: CapabilitiesDuringUpdate,
 
-    // TODO: make this variable in length
-    pub active_component_version_string: Option<[u8; 0xff]>,
+    /// WARNING: when encoding/decoding this is variable in size.
+    pub active_component_version_string: PldmFirmwareString,
 
-    // TODO: make this variable in length
-    // "If no pending firmware component exists, this field is zero bytes in length"
-    pub pending_component_version_string: Option<[u8; 0xff]>,
+    /// "If no pending firmware component exists, this field is zero bytes in length"
+    ///
+    /// **WARNING**: when encoding/decoding this is variable in size.
+    pub pending_component_version_string: PldmFirmwareString,
+}
+
+#[allow(clippy::too_many_arguments)]
+impl DownstreamDeviceParameterTable {
+    pub fn new(
+        downstream_device_index: DownstreamDeviceIndex,
+        active_component_comparison_stamp: u32,
+        active_component_version_string: PldmFirmwareString,
+        pending_component_version_string: PldmFirmwareString,
+        active_component_release_date: &str,
+        pending_component_comparison_stamp: u32,
+        component_activation_methods: ComponentActivationMethods,
+        capabilities_during_update: CapabilitiesDuringUpdate,
+        pending_component_release_date: &str,
+    ) -> Result<Self, PldmError> {
+        Ok(DownstreamDeviceParameterTable {
+            downstream_device_index: downstream_device_index.0,
+            active_component_comparison_stamp,
+            active_component_release_date: PldmTimeStamp::new(active_component_release_date)?,
+            pending_component_comparison_stamp,
+            pending_component_release_date: PldmTimeStamp::new(pending_component_release_date)?,
+            component_activation_methods,
+            capabilities_during_update,
+            active_component_version_string,
+            pending_component_version_string,
+        })
+    }
+
+    pub fn size(&self) -> usize {
+        size_of::<u16>() // downstream_device_index
+            + size_of::<u32>() // active_component_comparison_stamp
+            + size_of::<u8>() // ActiveComponentVersionStringType
+            + size_of::<u8>() // ActiveComponentVersionStringLength
+            + size_of::<PldmTimeStamp>()  // active_component_release_date
+            + size_of::<u32>() // pending_component_comparison_stamp
+            + size_of::<u8>() // PendingComponentVersionStringType
+            + size_of::<u8>() // PendingComponentVersionStringLength
+            + size_of::<PldmTimeStamp>() // pending_component_release_date
+            + size_of::<ComponentActivationMethods>() // component_activation_methods
+            + size_of::<CapabilitiesDuringUpdate>() // capabilities_during_update
+            // this is 6 although it should be 4
+            + self.active_component_version_string.str_len as usize
+            + self.pending_component_version_string.str_len as usize
+    }
+}
+
+/// This is a custom implementation, since the struct contains variable-length fields.
+/// [PldmFirmwareString] needs a custom codec as well, so we cannot derive it here.
+impl PldmCodec for DownstreamDeviceParameterTable {
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, crate::codec::PldmCodecError> {
+        if buffer.len() < self.size() {
+            return Err(crate::codec::PldmCodecError::BufferTooShort);
+        }
+
+        let mut offset = 0;
+        buffer[offset..offset + size_of::<u16>()]
+            .copy_from_slice(&self.downstream_device_index.to_le_bytes());
+        offset += size_of::<u16>();
+
+        buffer[offset..offset + size_of::<u32>()]
+            .copy_from_slice(&self.active_component_comparison_stamp.to_le_bytes());
+        offset += size_of::<u32>();
+
+        buffer[offset] = self.active_component_version_string.str_type;
+        offset += 1;
+
+        buffer[offset] = self.active_component_version_string.str_len;
+        offset += 1;
+
+        buffer[offset..offset + size_of::<PldmTimeStamp>()]
+            .copy_from_slice(&self.active_component_release_date.0);
+        offset += size_of::<PldmTimeStamp>();
+
+        buffer[offset..offset + size_of::<u32>()]
+            .copy_from_slice(&self.pending_component_comparison_stamp.to_le_bytes());
+        offset += size_of::<u32>();
+
+        buffer[offset] = self.pending_component_version_string.str_type;
+        offset += 1;
+
+        buffer[offset] = self.pending_component_version_string.str_len;
+        offset += 1;
+
+        buffer[offset..offset + size_of::<PldmTimeStamp>()]
+            .copy_from_slice(&self.pending_component_release_date.0);
+        offset += size_of::<PldmTimeStamp>();
+
+        buffer[offset..offset + size_of::<ComponentActivationMethods>()]
+            .copy_from_slice(&self.component_activation_methods.0.to_le_bytes());
+        offset += size_of::<ComponentActivationMethods>();
+
+        buffer[offset..offset + size_of::<CapabilitiesDuringUpdate>()]
+            .copy_from_slice(&self.capabilities_during_update.0.to_le_bytes());
+        offset += size_of::<CapabilitiesDuringUpdate>();
+
+        buffer[offset..offset + self.active_component_version_string.str_len as usize]
+            .copy_from_slice(
+                &self.active_component_version_string.str_data
+                    [..self.active_component_version_string.str_len as usize],
+            );
+        offset += self.active_component_version_string.str_len as usize;
+
+        buffer[offset..offset + self.pending_component_version_string.str_len as usize]
+            .copy_from_slice(
+                &self.pending_component_version_string.str_data
+                    [..self.pending_component_version_string.str_len as usize],
+            );
+        Ok(offset + self.pending_component_version_string.str_len as usize)
+    }
+
+    fn decode(buffer: &[u8]) -> Result<Self, crate::codec::PldmCodecError> {
+        // min size, assumed both version strings are 0 length
+        let min_size = size_of::<u16>()
+            + size_of::<u32>()
+            + size_of::<PldmTimeStamp>()
+            + size_of::<u32>()
+            + size_of::<PldmTimeStamp>()
+            + size_of::<ComponentActivationMethods>()
+            + size_of::<CapabilitiesDuringUpdate>();
+
+        if buffer.len() < min_size {
+            return Err(crate::codec::PldmCodecError::BufferTooShort);
+        }
+
+        let mut offset = 0;
+        let downstream_device_index = u16::from_le_bytes(
+            buffer[offset..offset + size_of::<u16>()]
+                .try_into()
+                .map_err(|_| crate::codec::PldmCodecError::InvalidData)?,
+        );
+        offset += size_of::<u16>();
+
+        let active_component_comparison_stamp = u32::from_le_bytes(
+            buffer[offset..offset + size_of::<u32>()]
+                .try_into()
+                .map_err(|_| crate::codec::PldmCodecError::InvalidData)?,
+        );
+        offset += size_of::<u32>();
+
+        // in the spec we now have to decode the string information one after another
+        // See [DownstreamDeviceParameterTable] warning
+        let active_component_version_string_type = buffer[offset];
+        offset += size_of::<u8>();
+
+        let active_component_version_string_length = buffer[offset];
+        offset += size_of::<u8>();
+
+        let active_component_release_date = PldmTimeStamp::try_read_from_prefix(
+            &buffer[offset..offset + size_of::<PldmTimeStamp>()],
+        )
+        .map_err(|_| PldmCodecError::InvalidData)?
+        .0;
+        offset += size_of::<PldmTimeStamp>();
+
+        let pending_component_comparison_stamp = u32::from_le_bytes(
+            buffer[offset..offset + size_of::<u32>()]
+                .try_into()
+                .map_err(|_| crate::codec::PldmCodecError::InvalidData)?,
+        );
+        offset += size_of::<u32>();
+
+        let pending_component_version_string_type = buffer[offset];
+        offset += size_of::<u8>();
+
+        let pending_component_version_string_length = buffer[offset];
+        offset += size_of::<u8>();
+
+        let pending_component_release_date = PldmTimeStamp::try_read_from_prefix(
+            &buffer[offset..offset + size_of::<PldmTimeStamp>()],
+        )
+        .map_err(|_| PldmCodecError::InvalidData)?
+        .0;
+        offset += size_of::<PldmTimeStamp>();
+
+        let component_activation_methods = ComponentActivationMethods::decode(&buffer[offset..])?;
+        offset += size_of::<ComponentActivationMethods>();
+
+        let capabilities_during_update = CapabilitiesDuringUpdate::decode(&buffer[offset..])?;
+        offset += size_of::<CapabilitiesDuringUpdate>();
+
+        let mut active_component_version_string = PldmFirmwareString::default();
+        active_component_version_string.str_type = active_component_version_string_type;
+        active_component_version_string.str_len = active_component_version_string_length;
+        active_component_version_string.str_data[..active_component_version_string_length as usize]
+            .copy_from_slice(
+                &buffer[offset..offset + active_component_version_string_length as usize],
+            );
+        offset += active_component_version_string_length as usize;
+
+        let mut pending_component_version_string = PldmFirmwareString::default();
+        pending_component_version_string.str_type = pending_component_version_string_type;
+        pending_component_version_string.str_len = pending_component_version_string_length;
+        pending_component_version_string.str_data
+            [..pending_component_version_string_length as usize]
+            .copy_from_slice(
+                &buffer[offset..offset + pending_component_version_string_length as usize],
+            );
+
+        Ok(DownstreamDeviceParameterTable {
+            downstream_device_index,
+            active_component_comparison_stamp,
+            active_component_release_date,
+            pending_component_comparison_stamp,
+            pending_component_release_date,
+            component_activation_methods,
+            capabilities_during_update,
+            active_component_version_string,
+            pending_component_version_string,
+        })
+    }
 }
 
 impl GetDownstreamFirmwareParametersResponse {
@@ -365,7 +923,7 @@ impl GetDownstreamFirmwareParametersResponse {
         completion_code: GetDownstreamFirmwareParametersResponseCode,
         next_data_transfer_handle: u32,
         transfer_flag: u8,
-        portions: Option<[GetDownstreamFirmwareParametersPortion; DOWNSTREAM_DEVICE_PORTION_COUNT]>,
+        portion: GetDownstreamFirmwareParametersPortion,
     ) -> Self {
         GetDownstreamFirmwareParametersResponse {
             hdr: PldmMsgHeader::new(
@@ -377,12 +935,93 @@ impl GetDownstreamFirmwareParametersResponse {
             completion_code: completion_code.into(),
             next_data_transfer_handle,
             transfer_flag,
-            portions,
+            portion,
         }
     }
 }
 
+impl PldmCodec for GetDownstreamFirmwareParametersResponse {
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, crate::codec::PldmCodecError> {
+        let size = size_of::<PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>>()
+            + size_of::<u8>()
+            + size_of::<u32>()
+            + size_of::<u8>()
+            + self.portion.size();
+
+        println!("DownstreamDeviceParameterTable encode size: {}", size);
+        println!("Buffer length: {}", buffer.len());
+
+        if buffer.len() < size {
+            return Err(crate::codec::PldmCodecError::BufferTooShort);
+        }
+
+        let mut offset = 0;
+        self.hdr
+            .write_to(&mut buffer[offset..offset + PLDM_MSG_HEADER_LEN])
+            .map_err(|_| crate::codec::PldmCodecError::BufferTooShort)?;
+        offset += PLDM_MSG_HEADER_LEN;
+
+        buffer[offset] = self.completion_code;
+        offset += size_of::<u8>();
+
+        buffer[offset..offset + size_of::<u32>()]
+            .copy_from_slice(&self.next_data_transfer_handle.to_le_bytes());
+        offset += size_of::<u32>();
+
+        buffer[offset] = self.transfer_flag;
+        offset += size_of::<u8>();
+
+        let bytes_written = self.portion.encode(&mut buffer[offset..])?;
+        offset += bytes_written;
+
+        Ok(offset)
+    }
+
+    fn decode(buffer: &[u8]) -> Result<Self, crate::codec::PldmCodecError> {
+        let min_size = size_of::<PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>>()
+            + size_of::<u8>()
+            + size_of::<u32>()
+            + size_of::<u8>()
+            + size_of::<FirmwareDeviceCapability>()
+            + size_of::<u16>();
+
+        if buffer.len() < min_size {
+            return Err(crate::codec::PldmCodecError::BufferTooShort);
+        }
+
+        let mut offset = 0;
+        let hdr = PldmMsgHeader::<[u8; PLDM_MSG_HEADER_LEN]>::read_from_bytes(
+            &buffer[offset..offset + PLDM_MSG_HEADER_LEN],
+        )
+        .map_err(|_| crate::codec::PldmCodecError::InvalidData)?;
+        offset += PLDM_MSG_HEADER_LEN;
+
+        let completion_code = buffer[offset];
+        offset += size_of::<u8>();
+
+        let next_data_transfer_handle = u32::from_le_bytes(
+            buffer[offset..offset + size_of::<u32>()]
+                .try_into()
+                .map_err(|_| crate::codec::PldmCodecError::InvalidData)?,
+        );
+        offset += size_of::<u32>();
+
+        let transfer_flag = buffer[offset];
+        offset += size_of::<u8>();
+
+        let portion = GetDownstreamFirmwareParametersPortion::decode(&buffer[offset..])?;
+        Ok(GetDownstreamFirmwareParametersResponse {
+            hdr,
+            completion_code,
+            next_data_transfer_handle,
+            transfer_flag,
+            portion,
+        })
+    }
+}
+
 bitfield! {
+    #[derive(Clone, Copy, FromBytes, IntoBytes, Immutable, PartialEq, Eq)]
     pub struct CapabilitiesDuringUpdate(u32);
     impl Debug;
     pub u32, reserved, _: 31, 5;
@@ -393,7 +1032,8 @@ bitfield! {
     pub u32, downstream_apply_state, set_downstream_apply_state: 0;
 }
 // DMTF0267 12.17
-#[derive(Debug, Clone, FromBytes, Immutable, PartialEq)]
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[repr(C, packed)]
 pub struct RequestDownstreamDeviceUpdateRequest {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
     // "This value shall be equal to or greater than firmware update baseline transfer size"
@@ -424,6 +1064,7 @@ impl RequestDownstreamDeviceUpdateRequest {
     }
 }
 
+#[derive(Debug, Clone, Immutable, PartialEq)]
 pub enum DDWillSendGetPackageDataCommand {
     FDPShouldObtainUALimited = 0x02,
     FDPShouldObtainLearn = 0x01,
@@ -460,6 +1101,8 @@ pldm_completion_code! {
     }
 }
 
+#[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[repr(C, packed)]
 pub struct RequestDownstreamDeviceUpdateResponse {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
 
@@ -502,7 +1145,7 @@ mod tests {
     use crate::codec::PldmCodec;
 
     #[test]
-    fn test_query_downstream_devices_request() {
+    fn test_query_downstream_devices_request_codec() {
         let instance_id: InstanceId = 0x01;
         let req = QueryDownstreamDevicesRequest::new(instance_id);
 
@@ -514,7 +1157,7 @@ mod tests {
     }
 
     #[test]
-    fn test_query_downstream_devices_response() {
+    fn test_query_downstream_devices_response_codec() {
         let instance_id: InstanceId = 0x01;
         let resp = QueryDownstreamDeviceResponse::new(
             instance_id,
@@ -532,7 +1175,7 @@ mod tests {
     }
 
     #[test]
-    fn query_downstream_identifiers_request() {
+    fn test_query_downstream_identifiers_request_codec() {
         let instance_id: InstanceId = 0x01;
         let downstream_data_device_handle = 0x12345678;
         let transfer_op_flag = TransferOperationFlag::GetFirstPart;
@@ -551,5 +1194,293 @@ mod tests {
     }
 
     #[test]
-    fn query_downstream_identifiers_response() {}
+    fn test_query_downstream_identifiers_response_codec() {
+        let instance_id: InstanceId = 0x01;
+        let resp = QueryDownstreamIdentifiersResponse::new(
+            instance_id,
+            QueryDownstreamIdentifiersResponseCode::BaseCodes(PldmBaseCompletionCode::Success),
+            0x12345678,
+            TransferOperationFlag::GetFirstPart as u8,
+            &[0u8; 16],
+        );
+
+        let mut buffer_encode = [0u8; 128];
+        let bytes_written = resp.encode(&mut buffer_encode).unwrap();
+        let decoded =
+            QueryDownstreamIdentifiersResponse::decode(&buffer_encode[..bytes_written]).unwrap();
+        assert_eq!(resp, decoded);
+    }
+
+    #[test]
+    fn test_get_downstream_firmware_parameters_request_codec() {
+        let instance_id: InstanceId = 0x01;
+        let req = GetDownstreamFirmwareParametersRequest::new(
+            instance_id,
+            0x12345678,
+            TransferOperationFlag::GetFirstPart,
+        );
+
+        let mut buffer_encode =
+            [0u8; core::mem::size_of::<GetDownstreamFirmwareParametersRequest>()];
+        req.encode(&mut buffer_encode).unwrap();
+
+        let decoded = GetDownstreamFirmwareParametersRequest::decode(&buffer_encode).unwrap();
+        assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn test_device_parameter_table_codec() {
+        let downstream_device_index = DownstreamDeviceIndex::try_from(1).unwrap();
+        let acvs = PldmFirmwareString::new("ascii", "test").unwrap();
+        let pcvs = PldmFirmwareString::new("ascii", "test").unwrap();
+
+        let table = DownstreamDeviceParameterTable::new(
+            downstream_device_index,
+            12345,
+            acvs,
+            pcvs,
+            "20250101",
+            12346,
+            ComponentActivationMethods(0),
+            CapabilitiesDuringUpdate(0),
+            "20250202",
+        )
+        .unwrap();
+
+        const STR_DATA_OFFSET: usize = size_of::<u16>()
+                + size_of::<u32>()
+                + 2 * size_of::<u8> ()// string meta data
+                + size_of::<PldmTimeStamp>()
+                + size_of::<u32>()
+                + 2 * size_of::<u8>()// string meta data
+                + size_of::<PldmTimeStamp>()
+                + size_of::<ComponentActivationMethods>()
+                + size_of::<CapabilitiesDuringUpdate>();
+
+        dbg!(STR_DATA_OFFSET);
+
+        let mut buffer = [0u8; STR_DATA_OFFSET + 4 + 4];
+        let bytes_written = table.encode(&mut buffer).unwrap();
+
+        // check if the strings were encoded correctly
+        let mut offset = STR_DATA_OFFSET;
+        assert_eq!(&buffer[offset..offset + 4], b"test");
+        offset += 4;
+
+        assert_eq!(&buffer[offset..offset + 4], b"test");
+
+        let decoded = DownstreamDeviceParameterTable::decode(&buffer[..bytes_written]).unwrap();
+        assert_eq!(table, decoded);
+    }
+
+    #[test]
+    fn test_get_downstream_firmware_parameters_portion_codec() {
+        let downstream_device_index = DownstreamDeviceIndex::try_from(1).unwrap();
+        let acvs = PldmFirmwareString::new("ascii", "test").unwrap();
+        let pcvs = PldmFirmwareString::new("ascii", "test").unwrap();
+
+        let downstream_device_parameter_table = DownstreamDeviceParameterTable::new(
+            downstream_device_index,
+            12345,
+            acvs,
+            pcvs,
+            "20250101",
+            12346,
+            ComponentActivationMethods(0),
+            CapabilitiesDuringUpdate(0),
+            "20250202",
+        )
+        .unwrap();
+
+        dbg!(size_of_val(&downstream_device_parameter_table));
+
+        let portion = GetDownstreamFirmwareParametersPortion {
+            get_downstream_firmware_parameters_capability: FirmwareDeviceCapability(0u32),
+            downstream_device_count: 1,
+            downstream_device_parameter_table,
+        };
+
+        let mut buffer = [0u8; 0xff0];
+        let bytes_written = portion.encode(&mut buffer).unwrap();
+
+        let decoded =
+            GetDownstreamFirmwareParametersPortion::decode(&buffer[..bytes_written]).unwrap();
+        assert_eq!(portion, decoded);
+    }
+
+    #[test]
+    fn test_get_downstream_firmware_parameters_response_codec() {
+        // todo!();
+        let instance_id: InstanceId = 0x01;
+        let downstream_device_index = DownstreamDeviceIndex::try_from(1).unwrap();
+        let cap: FirmwareDeviceCapability = FirmwareDeviceCapability(0u32);
+
+        let acvs = PldmFirmwareString::new("ascii", "test").unwrap();
+        let pcvs = PldmFirmwareString::new("ascii", "test").unwrap();
+
+        let downstream_device_parameter_table = DownstreamDeviceParameterTable::new(
+            downstream_device_index,
+            12345,
+            acvs,
+            pcvs,
+            "20250101",
+            12346,
+            ComponentActivationMethods(0),
+            CapabilitiesDuringUpdate(0),
+            "20250202",
+        )
+        .unwrap();
+
+        let portion = GetDownstreamFirmwareParametersPortion {
+            get_downstream_firmware_parameters_capability: cap,
+            downstream_device_count: 1,
+            downstream_device_parameter_table,
+        };
+
+        let resp = GetDownstreamFirmwareParametersResponse::new(
+            instance_id,
+            GetDownstreamFirmwareParametersResponseCode::BaseCodes(PldmBaseCompletionCode::Success),
+            0x12345678,
+            TransferOperationFlag::GetFirstPart as u8,
+            portion,
+        );
+
+        let mut buffer_encode = [0u8; 0xff0];
+        let bytes_written = resp.encode(&mut buffer_encode).unwrap();
+
+        let decoded =
+            GetDownstreamFirmwareParametersResponse::decode(&buffer_encode[..bytes_written])
+                .unwrap();
+        assert_eq!(resp, decoded);
+    }
+
+    #[test]
+    fn test_request_downstream_device_update_request_codec() {
+        let instance_id: InstanceId = 0x01;
+        let req = RequestDownstreamDeviceUpdateRequest::new(instance_id, 1024, 4, 512);
+
+        let mut buffer_encode = [0u8; core::mem::size_of::<RequestDownstreamDeviceUpdateRequest>()];
+        req.encode(&mut buffer_encode).unwrap();
+
+        let decoded = RequestDownstreamDeviceUpdateRequest::decode(&buffer_encode).unwrap();
+        assert_eq!(req, decoded);
+    }
+
+    #[test]
+    fn test_request_downstream_device_update_response_codec() {
+        let instance_id: InstanceId = 0x01;
+        let resp = RequestDownstreamDeviceUpdateResponse::new(
+            instance_id,
+            RequestDownstreamDeviceUpdateCode::BaseCodes(PldmBaseCompletionCode::Success),
+            256,
+            DDWillSendGetPackageDataCommand::FDPShouldObtainLearn,
+            512,
+        );
+
+        let mut buffer_encode =
+            [0u8; core::mem::size_of::<RequestDownstreamDeviceUpdateResponse>()];
+        resp.encode(&mut buffer_encode).unwrap();
+
+        let decoded = RequestDownstreamDeviceUpdateResponse::decode(&buffer_encode).unwrap();
+        assert_eq!(resp, decoded);
+    }
+
+    #[test]
+    fn test_downstream_device_codec() {
+        let descriptor = Descriptor {
+            descriptor_type: 0xff,
+            descriptor_length: 0x02,
+            descriptor_data: [0u8; 64],
+        };
+        let descriptors: [Descriptor; 3] = [descriptor.clone(), descriptor.clone(), descriptor];
+
+        const DESC_LEN: usize = size_of::<Descriptor>();
+        let mut descriptor_bytes: [u8; DESC_LEN * 3] = [0u8; DESC_LEN * 3];
+        let mut offset = 0;
+        for desc in descriptors.iter() {
+            descriptor_bytes[offset..offset + DESC_LEN].copy_from_slice(&desc.as_bytes());
+            offset += DESC_LEN;
+        }
+
+        let downstream_device_index = DownstreamDeviceIndex::try_from(1).unwrap();
+        let downstream_device = DownstreamDevice::new(downstream_device_index, &descriptor_bytes);
+
+        let mut buffer = [0u8; 256];
+        let bytes_written = downstream_device.encode(&mut buffer).unwrap();
+        let decoded = DownstreamDevice::decode(&buffer[..bytes_written]).unwrap();
+        assert_eq!(downstream_device, decoded);
+    }
+
+    #[test]
+    fn test_iterator_query_downstream_identifiers_response() {
+        let instance_id: InstanceId = 0x01;
+        let ph: PortionHeader = PortionHeader {
+            downstream_devices_length: 1,
+            number_of_downstream_devices: 1,
+        };
+        let dsdh: DownstreamDevicesHeader = DownstreamDevicesHeader {
+            downstream_devices_index: 1,
+            downstream_descriptor_count: 3,
+        };
+        let dsc_0: Descriptor = Descriptor {
+            descriptor_type: 0xff,
+            descriptor_length: 0x02,
+            descriptor_data: [0u8; 64],
+        };
+
+        let mut dsc_1 = dsc_0.clone();
+        dsc_1.descriptor_type = 0xfe;
+        dsc_1.descriptor_data = [1u8; 64];
+
+        let mut dsc_2 = dsc_0.clone();
+        dsc_2.descriptor_type = 0xfd;
+        dsc_2.descriptor_data = [2u8; 64];
+
+        const LEN: usize = size_of::<PortionHeader>()
+            + size_of::<DownstreamDevicesHeader>()
+            + 3 * size_of::<Descriptor>();
+        let mut offset = 0;
+        let mut portion: [u8; LEN] = [0u8; LEN];
+
+        portion[0..offset + size_of::<PortionHeader>()].copy_from_slice(&ph.as_bytes());
+        offset += size_of::<PortionHeader>();
+
+        portion[offset..offset + size_of::<DownstreamDevicesHeader>()]
+            .copy_from_slice(&dsdh.as_bytes());
+        offset += size_of::<DownstreamDevicesHeader>();
+
+        portion[offset..offset + size_of::<Descriptor>()].copy_from_slice(&dsc_0.as_bytes());
+        offset += size_of::<Descriptor>();
+
+        portion[offset..offset + size_of::<Descriptor>()].copy_from_slice(&dsc_1.as_bytes());
+        offset += size_of::<Descriptor>();
+
+        portion[offset..offset + size_of::<Descriptor>()].copy_from_slice(&dsc_2.as_bytes());
+
+        let mut qdir = QueryDownstreamIdentifiersResponse::new(
+            instance_id,
+            QueryDownstreamIdentifiersResponseCode::BaseCodes(PldmBaseCompletionCode::Success),
+            0x12345678,
+            0x00,
+            &portion,
+        );
+
+        // test iterator implementation
+        let mut qdir_iter = qdir.next();
+        let mut dsd_iter = qdir_iter.as_mut().unwrap().next();
+        assert!(dsd_iter.is_some());
+
+        dsd_iter = qdir_iter.as_mut().unwrap().next();
+        assert_eq!(dsc_1, dsd_iter.unwrap());
+
+        dsd_iter = qdir_iter.as_mut().unwrap().next();
+        assert_eq!(dsc_2, dsd_iter.unwrap());
+
+        qdir_iter = qdir.next();
+        assert!(qdir_iter.is_none());
+
+        // test try_at
+        assert!(qdir.try_at(0).is_ok());
+        assert!(qdir.try_at(1).is_err());
+    }
 }

--- a/src/message/firmware_update/query_downstream.rs
+++ b/src/message/firmware_update/query_downstream.rs
@@ -5,7 +5,7 @@ use crate::protocol::base::{
     PLDM_MSG_HEADER_LEN,
 };
 
-use crate::protocol::firmware_update::{Descriptor, FwUpdateCmd};
+use crate::protocol::firmware_update::{ComponentActivationMethods, Descriptor, FwUpdateCmd};
 use bitfield::bitfield;
 use zerocopy::{FromBytes, Immutable, IntoBytes};
 
@@ -238,6 +238,107 @@ impl DownstreamDescriptor {
     }
 }
 
+// #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C, packed)]
+pub struct GetDownstreamFirmwareParametersRequest {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+    pub data_transfer_handle: u32,
+    pub transfer_op_flag: u8,
+}
+
+impl GetDownstreamFirmwareParametersRequest {
+    pub fn new(
+        instance_id: InstanceId,
+        data_transfer_handle: u32,
+        transfer_op_flag: TransferOperationFlag,
+    ) -> Self {
+        GetDownstreamFirmwareParametersRequest {
+            hdr: PldmMsgHeader::new(
+                instance_id,
+                PldmMsgType::Request,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::GetDownstreamFirmwareParameters as u8,
+            ),
+            data_transfer_handle,
+            transfer_op_flag: transfer_op_flag as u8,
+        }
+    }
+}
+
+bitfield! {
+    #[derive(Clone, Copy, FromBytes, IntoBytes, Immutable, PartialEq, Eq)]
+    pub struct GetDownstreamFirmwareParametersCapability(u32);
+    impl Debug;
+    pub u32, reserved_0, _: 31, 10;
+    pub u32, secuirty_revision_number, set_secuirty_revision_number: 9;
+    pub u32, fdp_downgrade_restrictions, set_fdp_downgrade_restrictions: 8;
+    pub u32, fdp_update_mode_restrictions, set_fdp_update_mode_restrictions: 7, 4;
+    pub u32, reserved_1, _: 3;
+    pub u32, downstream_device_host_functionality, set_downstream_device_host_functionality: 2;
+    pub u32, component_update_failure_retry, set_component_update_failure_retry: 1;
+    pub u32, downstream_device_component_update_failure, set_downstream_device_component_update_failure: 0;
+}
+
+// #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct GetDownstreamFirmwareParametersResponse {
+    pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
+    pub completion_code: u8,
+    pub next_data_transfer_handle: u32,
+    pub transfer_flag: u8,
+
+    /// GetDownstreamFirmwareParametersPortion
+    ///
+    /// If the FDP has negotiated a PartSize as defined by DSP0240 and its NegotiateTransferParameters
+    /// command, then the maximum size for this field shall be equal to or less than that negotiated value.
+    /// Otherwise the FDP can determine the size for this field.
+    // TODO: check for PartSize and make this dynamic
+    pub portions: Option<[GetDownstreamFirmwareParametersPortion; DOWNSTREAM_DEVICE_PORTION_COUNT]>,
+}
+
+// #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C)]
+pub struct GetDownstreamFirmwareParametersPortion {
+    pub get_downstream_firmware_parameters_capability: GetDownstreamFirmwareParametersCapability,
+    pub downstream_device_count: u16,
+    pub downstream_device_parameter_table: Option<[DownstreamDeviceParameterTable; 8]>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+#[repr(C)]
+pub struct DownstreamDeviceParameterTable {
+    pub downstream_device_index: u16,
+    pub active_component_comparison_stamp: u32,
+    pub active_component_version_string_type: u8, // See VersionStringType
+    pub active_component_version_string_length: u8,
+    pub active_component_release_date: [u8; 8], // YYYYMMDD
+    pub pending_component_comparison_stamp: u32,
+    pub pending_component_version_string_type: u8, // See VersionStringType
+    pub pending_component_version_string_length: u8,
+    pub pending_component_release_date: [u8; 8], // YYYYMMDD
+    pub component_activation_methods: ComponentActivationMethods,
+
+    // TODO: make this variable in length
+    pub active_component_version_string: Option<[u8; 0xff]>,
+
+    // TODO: make this variable in length
+    // "If no pending firmware component exists, this field is zero bytes in length"
+    pub pending_component_version_string: Option<[u8; 0xff]>,
+}
+
+bitfield! {
+    pub struct CapabilitiesDuringUpdate(u32);
+    impl Debug;
+    pub u32, reserved, _: 31, 5;
+    pub u32, component_security_level_latest, set_component_security_level_latest: 4;
+    pub u32, security_revision_number_updateable, set_security_revision_number_updateable: 3;
+    pub u32, component_downgrade_capability, set_component_downgrade_capability: 2;
+    pub u32, downstream_updateable, set_downstream_updateable: 1;
+    pub u32, downstream_apply_state, set_downstream_apply_state: 0;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -289,6 +390,24 @@ mod tests {
         assert_eq!(ds.downstream_device_index, 10);
         assert_eq!(ds.downstream_descriptor_count, 0);
         assert!(ds.downstream_descriptors.is_none());
+    }
+
+    #[test]
+    fn test_get_downstream_firmware_parameters_request_manual() {
+        let req = GetDownstreamFirmwareParametersRequest {
+            hdr: PldmMsgHeader::new(
+                6,
+                PldmMsgType::Request,
+                PldmSupportedType::FwUpdate,
+                FwUpdateCmd::GetDownstreamFirmwareParameters as u8,
+            ),
+            data_transfer_handle: 0xAABBCCDD,
+            transfer_op_flag: 0,
+        };
+        assert_eq!(req.hdr.instance_id(), 6);
+        let handle = req.data_transfer_handle;
+        assert_eq!(handle, 0xAABBCCDD);
+        assert_eq!(req.transfer_op_flag, 0);
     }
 
     #[test]

--- a/src/message/firmware_update/request_cancel.rs
+++ b/src/message/firmware_update/request_cancel.rs
@@ -133,7 +133,7 @@ mod test {
     use crate::codec::PldmCodec;
 
     #[test]
-    fn test_cancel_update_request() {
+    fn test_cancel_update_request_codec() {
         let cancel_update_request = CancelUpdateRequest::new(0x01, PldmMsgType::Request);
         let mut buffer = [0u8; core::mem::size_of::<CancelUpdateRequest>()];
         cancel_update_request.encode(&mut buffer).unwrap();
@@ -142,7 +142,7 @@ mod test {
     }
 
     #[test]
-    fn test_cancel_update_response() {
+    fn test_cancel_update_response_codec() {
         let response = CancelUpdateResponse::new(
             0x01,
             0x00,

--- a/src/message/firmware_update/request_fw_data.rs
+++ b/src/message/firmware_update/request_fw_data.rs
@@ -1,6 +1,5 @@
 // Licensed under the Apache-2.0 license
-
-use crate::codec::{PldmCodec, PldmCodecError, PldmCodecWithLifetime};
+use crate::codec::{PldmCodecError, PldmCodecWithLifetime};
 use crate::protocol::base::{
     InstanceId, PldmMsgHeader, PldmMsgType, PldmSupportedType, PLDM_MSG_HEADER_LEN,
 };
@@ -106,15 +105,19 @@ impl<'a> PldmCodecWithLifetime<'a> for RequestFirmwareDataResponse<'a> {
             return Err(PldmCodecError::BufferTooShort);
         }
 
-        let (fixed, data) =
+        let (fixed, _) =
             RequestFirmwareDataResponseFixed::read_from_prefix(&buffer[..size]).unwrap();
-        Ok(RequestFirmwareDataResponse { fixed, data })
+        Ok(RequestFirmwareDataResponse {
+            fixed,
+            data: &buffer[size..],
+        })
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::codec::PldmCodec;
 
     #[test]
     fn test_request_firmware_data_request_codec() {

--- a/src/message/firmware_update/request_fw_data.rs
+++ b/src/message/firmware_update/request_fw_data.rs
@@ -129,7 +129,6 @@ mod test {
         assert_eq!(request, decoded_request);
     }
 
-    #[ignore]
     #[test]
     fn test_request_firmware_data_response_codec() {
         let data = [0u8; 512];
@@ -137,7 +136,7 @@ mod test {
         let mut buffer = [0u8; 1024];
         let bytes = response.encode(&mut buffer).unwrap();
 
-        let decoded_response = RequestFirmwareDataResponse::decode(&buffer[..bytes]);
-        assert!(decoded_response.is_err());
+        let decoded_response = RequestFirmwareDataResponse::decode(&buffer[..bytes]).unwrap();
+        assert_eq!(response, decoded_response);
     }
 }

--- a/src/message/firmware_update/request_fw_data.rs
+++ b/src/message/firmware_update/request_fw_data.rs
@@ -1,6 +1,6 @@
 // Licensed under the Apache-2.0 license
 
-use crate::codec::{PldmCodec, PldmCodecError};
+use crate::codec::{PldmCodec, PldmCodecError, PldmCodecWithLifetime};
 use crate::protocol::base::{
     InstanceId, PldmMsgHeader, PldmMsgType, PldmSupportedType, PLDM_MSG_HEADER_LEN,
 };
@@ -40,6 +40,7 @@ impl RequestFirmwareDataRequest {
 
 #[derive(Debug, Clone, FromBytes, IntoBytes, Immutable, PartialEq)]
 #[repr(C, packed)]
+// TODO: this is calitpra code, but imho this structure is too clunky.
 pub struct RequestFirmwareDataResponseFixed {
     pub hdr: PldmMsgHeader<[u8; PLDM_MSG_HEADER_LEN]>,
     pub completion_code: u8,
@@ -52,12 +53,12 @@ pub struct RequestFirmwareDataResponse<'a> {
     pub data: &'a [u8],
 }
 
-impl RequestFirmwareDataResponse<'_> {
+impl<'a> RequestFirmwareDataResponse<'a> {
     pub fn new(
         instance_id: InstanceId,
         completion_code: u8,
-        data: &[u8],
-    ) -> RequestFirmwareDataResponse {
+        data: &'a [u8],
+    ) -> RequestFirmwareDataResponse<'a> {
         let fixed = RequestFirmwareDataResponseFixed {
             hdr: PldmMsgHeader::new(
                 instance_id,
@@ -77,7 +78,7 @@ impl RequestFirmwareDataResponse<'_> {
     }
 }
 
-impl PldmCodec for RequestFirmwareDataResponse<'_> {
+impl<'a> PldmCodecWithLifetime<'a> for RequestFirmwareDataResponse<'a> {
     fn encode(&self, buffer: &mut [u8]) -> Result<usize, PldmCodecError> {
         if buffer.len() < self.codec_size_in_bytes() {
             return Err(PldmCodecError::BufferTooShort);
@@ -99,8 +100,15 @@ impl PldmCodec for RequestFirmwareDataResponse<'_> {
     }
 
     // Decoding is implemented for this struct. The caller should use the `length` field in the request to read the image portion data from the buffer.
-    fn decode(_buffer: &[u8]) -> Result<Self, PldmCodecError> {
-        Err(PldmCodecError::Unsupported)
+    fn decode(buffer: &'a [u8]) -> Result<Self, PldmCodecError> {
+        let size = core::mem::size_of::<RequestFirmwareDataResponseFixed>();
+        if buffer.len() < size {
+            return Err(PldmCodecError::BufferTooShort);
+        }
+
+        let (fixed, data) =
+            RequestFirmwareDataResponseFixed::read_from_prefix(&buffer[..size]).unwrap();
+        Ok(RequestFirmwareDataResponse { fixed, data })
     }
 }
 
@@ -109,20 +117,23 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_request_firmware_data_request() {
+    fn test_request_firmware_data_request_codec() {
         let request = RequestFirmwareDataRequest::new(1, PldmMsgType::Request, 0, 64);
         let mut buffer = [0u8; 1024];
         let bytes = request.encode(&mut buffer).unwrap();
+
         let decoded_request = RequestFirmwareDataRequest::decode(&buffer[..bytes]).unwrap();
         assert_eq!(request, decoded_request);
     }
 
+    #[ignore]
     #[test]
-    fn test_request_firmware_data_response() {
+    fn test_request_firmware_data_response_codec() {
         let data = [0u8; 512];
         let response = RequestFirmwareDataResponse::new(1, 0, &data);
         let mut buffer = [0u8; 1024];
         let bytes = response.encode(&mut buffer).unwrap();
+
         let decoded_response = RequestFirmwareDataResponse::decode(&buffer[..bytes]);
         assert!(decoded_response.is_err());
     }

--- a/src/message/firmware_update/request_update.rs
+++ b/src/message/firmware_update/request_update.rs
@@ -235,7 +235,7 @@ mod tests {
     use crate::protocol::firmware_update::PldmFirmwareString;
 
     #[test]
-    fn test_request_update_request() {
+    fn test_request_update_request_codec() {
         let request = RequestUpdateRequest::new(
             0,
             PldmMsgType::Request,
@@ -255,7 +255,7 @@ mod tests {
     }
 
     #[test]
-    fn test_request_update_response() {
+    fn test_request_update_response_codec() {
         let response = RequestUpdateResponse::new(1, 0, 128, 0x02, Some(2048));
 
         let mut buffer = [0u8; 512];

--- a/src/message/firmware_update/transfer_complete.rs
+++ b/src/message/firmware_update/transfer_complete.rs
@@ -101,7 +101,7 @@ mod test {
     use crate::codec::PldmCodec;
 
     #[test]
-    fn test_transfer_complete_request() {
+    fn test_transfer_complete_request_codec() {
         let request = TransferCompleteRequest::new(
             0x01,
             PldmMsgType::Request,
@@ -114,7 +114,7 @@ mod test {
     }
 
     #[test]
-    fn test_transfer_complete_response() {
+    fn test_transfer_complete_response_codec() {
         let response = TransferCompleteResponse::new(0x01, 0x00);
         let mut buffer = [0u8; core::mem::size_of::<TransferCompleteResponse>()];
         response.encode(&mut buffer).unwrap();

--- a/src/message/firmware_update/update_component.rs
+++ b/src/message/firmware_update/update_component.rs
@@ -299,7 +299,7 @@ mod test {
     use super::*;
 
     #[test]
-    fn test_update_component_request() {
+    fn test_update_component_request_codec() {
         let request = UpdateComponentRequest::new(
             0,
             PldmMsgType::Request,
@@ -319,7 +319,7 @@ mod test {
     }
 
     #[test]
-    fn test_update_component_response() {
+    fn test_update_component_response_codec() {
         let response = UpdateComponentResponse::new(
             0,
             0x00,

--- a/src/message/firmware_update/verify_complete.rs
+++ b/src/message/firmware_update/verify_complete.rs
@@ -91,7 +91,7 @@ mod test {
     use crate::codec::PldmCodec;
 
     #[test]
-    fn test_verify_complete_request() {
+    fn test_verify_complete_request_codec() {
         let request =
             VerifyCompleteRequest::new(0x01, PldmMsgType::Request, VerifyResult::VerifySuccess);
         let mut buffer = [0u8; core::mem::size_of::<VerifyCompleteRequest>()];
@@ -101,7 +101,7 @@ mod test {
     }
 
     #[test]
-    fn test_verify_complete_response() {
+    fn test_verify_complete_response_codec() {
         let response = VerifyCompleteResponse::new(0x01, 0x00);
         let mut buffer = [0u8; core::mem::size_of::<VerifyCompleteResponse>()];
         response.encode(&mut buffer).unwrap();

--- a/src/protocol/base.rs
+++ b/src/protocol/base.rs
@@ -289,6 +289,26 @@ macro_rules! pldm_completion_code {
                 }
             }
         }
+
+        impl TryFrom<u8> for $enum_name {
+            type Error = crate::error::PldmError;
+
+            fn try_from(code: u8) -> Result<Self, Self::Error> {
+                if let Ok(base_code) = PldmBaseCompletionCode::try_from(code) {
+                    return Ok($enum_name::BaseCodes(base_code));
+                }
+
+                match FwUpdateCompletionCode::try_from(code) {
+                    $(
+                        Ok(FwUpdateCompletionCode::$variant) => {
+                            Ok($enum_name::$variant)
+                        }
+                    )*
+                    Ok(_) => Err(crate::error::PldmError::InvalidCompletionCode),
+                    Err(e) => Err(e),
+                }
+        }
+    }
     };
 }
 

--- a/src/protocol/base.rs
+++ b/src/protocol/base.rs
@@ -90,7 +90,7 @@ pub enum PldmHeaderVersion {
     Version0 = 0x00,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 #[repr(u8)]
 pub enum PldmBaseCompletionCode {
     Success = 0x00,
@@ -256,10 +256,46 @@ impl PldmFailureResponse {
     }
 }
 
+/// Macro to define PLDM completion code enum with base codes and custom codes.
+/// By default, the entire [PldmBaseCompletionCode] is included as a
+/// variant named `BaseCodes`. The additional custom completion codes can be
+/// specified as variants, e.g. [FwUpdateCompletionCode].
+///
+/// This macro is useful for the completion codes for the command responses, to ensure
+/// type safety while still allowing the use of base completion codes and an
+/// arbitrary number of custom completion codes specific to the command.
+#[macro_export]
+macro_rules! pldm_completion_code {
+    (
+        $enum_name:ident {
+            $($variant:ident),* $(,)?
+        }
+    ) => {
+        pub enum $enum_name {
+            BaseCodes(PldmBaseCompletionCode),
+            $($variant),*
+        }
+
+        impl From<$enum_name> for u8 {
+            fn from(code: $enum_name) -> Self {
+                match code {
+                    $enum_name::BaseCodes(code) => code as u8,
+                    $(
+                        $enum_name::$variant => {
+                            FwUpdateCompletionCode::$variant as u8
+                        }
+                    )*
+                }
+            }
+        }
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::codec::PldmCodec;
+    use crate::protocol::firmware_update::FwUpdateCompletionCode;
 
     #[test]
     fn test_pldm_msg_header() {
@@ -298,5 +334,23 @@ mod tests {
 
         let decoded_resp = PldmFailureResponse::decode(&buffer).unwrap();
         assert_eq!(resp, decoded_resp);
+    }
+
+    #[test]
+    fn test_pldm_completion_code_macro() {
+        pldm_completion_code! {
+            TestEnum {
+                InvalidStateForCommand,
+                NoDeviceMetadata,
+                InvalidTransferHandle,
+                InvalidTransferOperationFlag,
+                PackageDataError,
+            }
+        }
+
+        let base = TestEnum::BaseCodes(PldmBaseCompletionCode::Success);
+        if let TestEnum::BaseCodes(i) = base {
+            assert_eq!(i, PldmBaseCompletionCode::Success);
+        }
     }
 }

--- a/src/protocol/base.rs
+++ b/src/protocol/base.rs
@@ -291,7 +291,7 @@ macro_rules! pldm_completion_code {
         }
 
         impl TryFrom<u8> for $enum_name {
-            type Error = crate::error::PldmError;
+            type Error = $crate::error::PldmError;
 
             fn try_from(code: u8) -> Result<Self, Self::Error> {
                 if let Ok(base_code) = PldmBaseCompletionCode::try_from(code) {
@@ -304,7 +304,7 @@ macro_rules! pldm_completion_code {
                             Ok($enum_name::$variant)
                         }
                     )*
-                    Ok(_) => Err(crate::error::PldmError::InvalidCompletionCode),
+                    Ok(_) => Err($crate::error::PldmError::InvalidCompletionCode),
                     Err(e) => Err(e),
                 }
         }

--- a/src/protocol/base.rs
+++ b/src/protocol/base.rs
@@ -271,6 +271,7 @@ macro_rules! pldm_completion_code {
             $($variant:ident),* $(,)?
         }
     ) => {
+        #[derive(PartialEq, Debug)]
         pub enum $enum_name {
             BaseCodes(PldmBaseCompletionCode),
             $($variant),*

--- a/src/protocol/base.rs
+++ b/src/protocol/base.rs
@@ -259,7 +259,7 @@ impl PldmFailureResponse {
 /// Macro to define PLDM completion code enum with base codes and custom codes.
 /// By default, the entire [PldmBaseCompletionCode] is included as a
 /// variant named `BaseCodes`. The additional custom completion codes can be
-/// specified as variants, e.g. [FwUpdateCompletionCode].
+/// specified as variants of [FwUpdateCompletionCode].
 ///
 /// This macro is useful for the completion codes for the command responses, to ensure
 /// type safety while still allowing the use of base completion codes and an

--- a/src/protocol/firmware_update.rs
+++ b/src/protocol/firmware_update.rs
@@ -31,6 +31,14 @@ pub enum FwUpdateCmd {
     GetStatus = 0x1B,
     CancelUpdateComponent = 0x1C,
     CancelUpdate = 0x1D,
+    // new
+    QueryDownstreamDevices = 0x03, // defined in DSP0267
+    QueryDownstreamIdentifiers = 0x04,
+    GetDownstreamFirmwareParameters = 0x05,
+    RequestDownstreamDeviceUpdate = 0x20,
+    GetPackageData = 0x11,
+    GetDeviceMetaData = 0x12,
+    GetMetaData = 0x19,
 }
 
 impl TryFrom<u8> for FwUpdateCmd {
@@ -51,6 +59,13 @@ impl TryFrom<u8> for FwUpdateCmd {
             0x1B => Ok(FwUpdateCmd::GetStatus),
             0x1C => Ok(FwUpdateCmd::CancelUpdateComponent),
             0x1D => Ok(FwUpdateCmd::CancelUpdate),
+            0x03 => Ok(FwUpdateCmd::QueryDownstreamDevices),
+            0x04 => Ok(FwUpdateCmd::QueryDownstreamIdentifiers),
+            0x05 => Ok(FwUpdateCmd::GetDownstreamFirmwareParameters),
+            0x20 => Ok(FwUpdateCmd::RequestDownstreamDeviceUpdate),
+            0x11 => Ok(FwUpdateCmd::GetPackageData),
+            0x12 => Ok(FwUpdateCmd::GetDeviceMetaData),
+            0x19 => Ok(FwUpdateCmd::GetMetaData),
             _ => Err(PldmError::UnsupportedCmd),
         }
     }

--- a/src/protocol/firmware_update.rs
+++ b/src/protocol/firmware_update.rs
@@ -5,7 +5,7 @@ use crate::error::PldmError;
 use bitfield::bitfield;
 use core::convert::TryFrom;
 use core::fmt;
-use zerocopy::{FromBytes, Immutable, IntoBytes};
+use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
 
 pub const PLDM_FWUP_COMPONENT_RELEASE_DATA_LEN: usize = 8;
 pub const PLDM_FWUP_BASELINE_TRANSFER_SIZE: usize = 32;
@@ -285,7 +285,7 @@ pub fn get_descriptor_length(descriptor_type: DescriptorType) -> usize {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, FromBytes, IntoBytes, Immutable, KnownLayout)]
 #[repr(C)]
 pub struct Descriptor {
     pub descriptor_type: u16,
@@ -333,74 +333,77 @@ impl Descriptor {
     }
 }
 
-impl PldmCodec for Descriptor {
-    fn encode(&self, buffer: &mut [u8]) -> Result<usize, PldmCodecError> {
-        if buffer.len() < self.codec_size_in_bytes() {
-            return Err(PldmCodecError::BufferTooShort);
-        }
-        let mut offset = 0;
+// impl PldmCodec for Descriptor {
+//     fn encode(&self, buffer: &mut [u8]) -> Result<usize, PldmCodecError> {
+//         if buffer.len() < self.codec_size_in_bytes() {
+//             return Err(PldmCodecError::BufferTooShort);
+//         }
+//         let mut offset = 0;
 
-        self.descriptor_type
-            .write_to(&mut buffer[offset..offset + core::mem::size_of::<u16>()])
-            .unwrap();
-        offset += core::mem::size_of::<u16>();
+//         self.descriptor_type
+//             .write_to(&mut buffer[offset..offset + core::mem::size_of::<u16>()])
+//             .unwrap();
+//         offset += core::mem::size_of::<u16>();
 
-        self.descriptor_length
-            .write_to(&mut buffer[offset..offset + core::mem::size_of::<u16>()])
-            .unwrap();
-        offset += core::mem::size_of::<u16>();
+//         self.descriptor_length
+//             .write_to(&mut buffer[offset..offset + core::mem::size_of::<u16>()])
+//             .unwrap();
+//         offset += core::mem::size_of::<u16>();
 
-        self.descriptor_data[..self.descriptor_length as usize]
-            .write_to(&mut buffer[offset..offset + self.descriptor_length as usize])
-            .unwrap();
-        offset += self.descriptor_length as usize;
+//         self.descriptor_data[..self.descriptor_length as usize]
+//             .write_to(&mut buffer[offset..offset + self.descriptor_length as usize])
+//             .unwrap();
+//         offset += self.descriptor_length as usize;
 
-        Ok(offset)
-    }
+//         Ok(offset)
+//     }
 
-    fn decode(buffer: &[u8]) -> Result<Self, PldmCodecError> {
-        let mut offset = 0;
+//     fn decode(buffer: &[u8]) -> Result<Self, PldmCodecError> {
+//         let mut offset = 0;
 
-        let descriptor_type = u16::read_from_bytes(
-            buffer
-                .get(offset..offset + core::mem::size_of::<u16>())
-                .ok_or(PldmCodecError::BufferTooShort)?,
-        )
-        .unwrap();
-        offset += core::mem::size_of::<u16>();
+//         let descriptor_type = u16::read_from_bytes(
+//             buffer
+//                 .get(offset..offset + core::mem::size_of::<u16>())
+//                 .ok_or(PldmCodecError::BufferTooShort)?,
+//         )
+//         .unwrap();
+//         offset += core::mem::size_of::<u16>();
 
-        let descriptor_length = u16::read_from_bytes(
-            buffer
-                .get(offset..offset + core::mem::size_of::<u16>())
-                .ok_or(PldmCodecError::BufferTooShort)?,
-        )
-        .unwrap();
-        offset += core::mem::size_of::<u16>();
+//         let descriptor_length = u16::read_from_bytes(
+//             buffer
+//                 .get(offset..offset + core::mem::size_of::<u16>())
+//                 .ok_or(PldmCodecError::BufferTooShort)?,
+//         )
+//         .unwrap();
+//         offset += core::mem::size_of::<u16>();
 
-        let mut descriptor_data = [0u8; DESCRIPTOR_DATA_MAX_LEN];
-        descriptor_data[..descriptor_length as usize].copy_from_slice(
-            buffer
-                .get(offset..offset + descriptor_length as usize)
-                .ok_or(PldmCodecError::BufferTooShort)?,
-        );
+//         let mut descriptor_data = [0u8; DESCRIPTOR_DATA_MAX_LEN];
+//         descriptor_data[..descriptor_length as usize].copy_from_slice(
+//             buffer
+//                 .get(offset..offset + descriptor_length as usize)
+//                 .ok_or(PldmCodecError::BufferTooShort)?,
+//         );
 
-        Ok(Descriptor {
-            descriptor_type,
-            descriptor_length,
-            descriptor_data,
-        })
-    }
-}
+//         Ok(Descriptor {
+//             descriptor_type,
+//             descriptor_length,
+//             descriptor_data,
+//         })
+//     }
+// }
 
 bitfield! {
+    /// FDPCapabilitiesDuringUpdate
+    ///
+    /// DSP0267, Table 20
     #[derive(Clone, Copy, FromBytes, IntoBytes, Immutable, PartialEq, Eq, Default)]
     pub struct FirmwareDeviceCapability(u32);
     impl Debug;
-    pub u32, reserved, _: 31, 10;
+    pub u32, reserved_0, _: 31, 10;
     pub u32, svn_update_support, set_svn_update_support: 9;
     pub u32, downgrade_restriction, set_downgrade_restriction: 8;
     pub u32, update_mode_restriction, set_update_mode_restriction: 7, 4;
-    pub u32, partial_updates, set_partial_updates: 3;
+    pub u32, reserved_1, _: 3;
     pub u32, host_func_reduced, set_func_reduced: 2;
     pub u32, update_failure_retry, set_update_failure_retry: 1;
     pub u32, update_failure_recovery, set_update_failure_recovery: 0;
@@ -466,7 +469,8 @@ impl TryFrom<u16> for ComponentClassification {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, FromBytes, IntoBytes)]
+#[repr(C, packed)]
 pub struct PldmFirmwareString {
     pub str_type: u8,
     pub str_len: u8,
@@ -508,6 +512,69 @@ impl PldmFirmwareString {
         Ok(PldmFirmwareString {
             str_type: str_type as u8,
             str_len: fw_str.len() as u8,
+            str_data,
+        })
+    }
+}
+
+/// This implementation is necessary to ensure, that only the valid portion of
+/// the str_data array is encoded/decoded, not it's entirety.
+/// For that we have to ensure, that [PldmFirmwareString] does not implement all
+/// the traits automatically derived by [zerocopy].
+impl PldmCodec for PldmFirmwareString {
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, PldmCodecError> {
+        if buffer.len() < self.str_len as usize + 2 * size_of::<u8>() {
+            return Err(PldmCodecError::BufferTooShort);
+        }
+        let mut offset = 0;
+
+        self.str_type
+            .write_to(&mut buffer[offset..offset + core::mem::size_of::<u8>()])
+            .unwrap();
+        offset += core::mem::size_of::<u8>();
+
+        self.str_len
+            .write_to(&mut buffer[offset..offset + core::mem::size_of::<u8>()])
+            .unwrap();
+        offset += core::mem::size_of::<u8>();
+
+        self.str_data[..self.str_len as usize]
+            .write_to(&mut buffer[offset..offset + self.str_len as usize])
+            .unwrap();
+        offset += self.str_len as usize;
+
+        Ok(offset)
+    }
+
+    fn decode(buffer: &[u8]) -> Result<Self, PldmCodecError> {
+        let mut offset = 0;
+
+        let str_type = u8::read_from_bytes(
+            buffer
+                .get(offset..offset + core::mem::size_of::<u8>())
+                .ok_or(PldmCodecError::BufferTooShort)?,
+        )
+        .unwrap();
+        offset += core::mem::size_of::<u8>();
+
+        let str_len = u8::read_from_bytes(
+            buffer
+                .get(offset..offset + core::mem::size_of::<u8>())
+                .ok_or(PldmCodecError::BufferTooShort)?,
+        )
+        .unwrap();
+        offset += core::mem::size_of::<u8>();
+
+        let mut str_data = [0u8; PLDM_FWUP_IMAGE_SET_VER_STR_MAX_LEN];
+        str_data[..str_len as usize].copy_from_slice(
+            buffer
+                .get(offset..offset + str_len as usize)
+                .ok_or(PldmCodecError::BufferTooShort)?,
+        );
+
+        Ok(PldmFirmwareString {
+            str_type,
+            str_len,
             str_data,
         })
     }
@@ -898,5 +965,41 @@ mod test {
         let active_fw_ver = component_parameter_entry.get_active_fw_ver();
         assert_eq!(active_firmware_string, active_fw_ver);
         assert!(active_firmware_string < pending_firmware_string);
+    }
+
+    #[test]
+    fn test_pldm_firmware_string_codec() {
+        let test_str = "test";
+        let fw_string = PldmFirmwareString::new("ASCII", &test_str).unwrap();
+        assert_eq!(fw_string.str_type, VersionStringType::Ascii as u8);
+        assert_eq!(fw_string.str_len, test_str.len() as u8);
+        assert_eq!(&fw_string.str_data[..fw_string.str_len as usize], b"test");
+
+        let mut buffer = [0u8; 2 + 4];
+        let bytes = fw_string.encode(&mut buffer).unwrap();
+        assert_eq!(bytes, 2 + 4);
+
+        let decoded_fw_string = PldmFirmwareString::decode(&buffer).unwrap();
+        assert_eq!(fw_string, decoded_fw_string);
+
+        let empty_fw_string = PldmFirmwareString::new("ASCII", "").unwrap();
+        assert_eq!(empty_fw_string.str_type, VersionStringType::Ascii as u8);
+        assert_eq!(empty_fw_string.str_len, 0);
+        let mut empty_buffer = [0u8; 2];
+        let bytes = empty_fw_string.encode(&mut empty_buffer).unwrap();
+        assert_eq!(bytes, 2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_pldm_firmware_string_codec_invalid_size() {
+        let test_str = "test";
+        let fw_string = PldmFirmwareString::new("ASCII", &test_str).unwrap();
+        assert_eq!(fw_string.str_type, VersionStringType::Ascii as u8);
+        assert_eq!(fw_string.str_len, test_str.len() as u8);
+        assert_eq!(&fw_string.str_data[..fw_string.str_len as usize], b"test");
+
+        let mut buffer = [0u8; 0];
+        fw_string.encode(&mut buffer).unwrap();
     }
 }

--- a/src/protocol/firmware_update.rs
+++ b/src/protocol/firmware_update.rs
@@ -93,6 +93,9 @@ pub enum FwUpdateCompletionCode {
     InvalidTransferOperationFlag = 0x91,
     ActivatePendingImageNotPermitted = 0x92,
     PackageDataError = 0x93,
+    NoOpaqueData = 0x94,
+    UpdateSecurityRevisionNotPermitted = 0x95,
+    DownstreamDeviceListChanged = 0x96,
 }
 
 impl TryFrom<u8> for FwUpdateCompletionCode {

--- a/src/protocol/firmware_update.rs
+++ b/src/protocol/firmware_update.rs
@@ -5,7 +5,7 @@ use crate::error::PldmError;
 use bitfield::bitfield;
 use core::convert::TryFrom;
 use core::fmt;
-use zerocopy::{FromBytes, Immutable, IntoBytes, KnownLayout};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
 
 pub const PLDM_FWUP_COMPONENT_RELEASE_DATA_LEN: usize = 8;
 pub const PLDM_FWUP_BASELINE_TRANSFER_SIZE: usize = 32;
@@ -285,7 +285,7 @@ pub fn get_descriptor_length(descriptor_type: DescriptorType) -> usize {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, FromBytes, IntoBytes, Immutable, KnownLayout)]
+#[derive(Debug, Copy, Clone, PartialEq, FromBytes)]
 #[repr(C)]
 pub struct Descriptor {
     pub descriptor_type: u16,
@@ -330,6 +330,112 @@ impl Descriptor {
 
     pub fn codec_size_in_bytes(&self) -> usize {
         core::mem::size_of::<u16>() * 2 + self.descriptor_length as usize
+    }
+
+    /// Calculates the total length of a list of descriptors from a blob.
+    ///
+    /// This simplifies the use case where multiple descriptors are used in a message,
+    /// and the total length needs to be calculated.
+    /// It follows the linked list of descriptors by decoding each one in sequence.
+    ///
+    /// The blob must start with the first descriptor, but may contain additional data after the last descriptor.
+    ///
+    /// ```rust
+    /// use pldm_lib::protocol::firmware_update::{Descriptor, DescriptorType, get_descriptor_length};
+    /// use crate::pldm_lib::codec::PldmCodec;
+    ///
+    /// let dsc_0 = Descriptor::new(DescriptorType::PciVendorId, &[0x11, 0x22]).unwrap();
+    /// let dsc_1 = Descriptor::new(DescriptorType::PciVendorId, &[0x33, 0x44]).unwrap();
+    /// const BLOB_LEN: usize = (size_of::<u16>() * 2 + 2 * size_of::<u8>()) * 2 as usize;
+    /// let mut blob = [0u8; BLOB_LEN];
+    ///
+    /// let offset = dsc_0.encode(&mut blob[0..]).unwrap();
+    /// let _ = dsc_1.encode(&mut blob[offset..]).unwrap();
+    ///
+    /// let total_len = Descriptor::try_get_descriptor_length_from_blob(&blob, 2).unwrap();
+    /// assert_eq!(total_len, dsc_0.codec_size_in_bytes() + dsc_1.codec_size_in_bytes());
+    /// ```
+    pub fn try_get_descriptor_length_from_blob(
+        blob: &[u8],
+        desc_count: usize,
+    ) -> Result<usize, PldmCodecError> {
+        let mut offset = 0;
+        let mut total_len = 0;
+
+        for _ in 0..desc_count {
+            let descriptor = Descriptor::decode(&blob[offset..])?;
+            total_len += descriptor.codec_size_in_bytes();
+            offset += descriptor.codec_size_in_bytes();
+        }
+
+        Ok(total_len)
+    }
+}
+
+impl PldmCodec for Descriptor {
+    /// Custom encode implementation of PldmCodec for Descriptor to handle variable-length.
+    ///
+    /// The descriptor_data field is variable-length, so we need to ensure that only the valid portion
+    /// of the array is encoded, not all data of the fixed size array of length [DESCRIPTOR_DATA_MAX_LEN].
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, PldmCodecError> {
+        if buffer.len() < self.codec_size_in_bytes() {
+            return Err(PldmCodecError::BufferTooShort);
+        }
+        let mut offset = 0;
+
+        self.descriptor_type
+            .write_to(&mut buffer[offset..offset + core::mem::size_of::<u16>()])
+            .unwrap();
+        offset += core::mem::size_of::<u16>();
+
+        self.descriptor_length
+            .write_to(&mut buffer[offset..offset + core::mem::size_of::<u16>()])
+            .unwrap();
+        offset += core::mem::size_of::<u16>();
+
+        self.descriptor_data[..self.descriptor_length as usize]
+            .write_to(&mut buffer[offset..offset + self.descriptor_length as usize])
+            .unwrap();
+        offset += self.descriptor_length as usize;
+
+        Ok(offset)
+    }
+
+    /// Custom decode implementation of PldmCodec for Descriptor to handle variable-length.
+    ///
+    /// The descriptor_data field is variable-length, so we need to ensure that only the valid portion
+    /// of the array is decoded, not all data of the fixed size array of length [DESCRIPTOR_DATA_MAX_LEN].
+    fn decode(buffer: &[u8]) -> Result<Self, PldmCodecError> {
+        let mut offset = 0;
+
+        let descriptor_type = u16::read_from_bytes(
+            buffer
+                .get(offset..offset + core::mem::size_of::<u16>())
+                .ok_or(PldmCodecError::BufferTooShort)?,
+        )
+        .unwrap();
+        offset += core::mem::size_of::<u16>();
+
+        let descriptor_length = u16::read_from_bytes(
+            buffer
+                .get(offset..offset + core::mem::size_of::<u16>())
+                .ok_or(PldmCodecError::BufferTooShort)?,
+        )
+        .unwrap();
+        offset += core::mem::size_of::<u16>();
+
+        let mut descriptor_data = [0u8; DESCRIPTOR_DATA_MAX_LEN];
+        descriptor_data[..descriptor_length as usize].copy_from_slice(
+            buffer
+                .get(offset..offset + descriptor_length as usize)
+                .ok_or(PldmCodecError::BufferTooShort)?,
+        );
+
+        Ok(Descriptor {
+            descriptor_type,
+            descriptor_length,
+            descriptor_data,
+        })
     }
 }
 
@@ -868,10 +974,28 @@ mod test {
             descriptor.descriptor_length,
             get_descriptor_length(DescriptorType::Uuid) as u16
         );
-        let mut buffer = [0u8; 512];
+        let mut buffer = [0u8; core::mem::size_of::<Descriptor>()];
         descriptor.encode(&mut buffer).unwrap();
+
         let decoded_descriptor = Descriptor::decode(&buffer).unwrap();
         assert_eq!(descriptor, decoded_descriptor);
+
+        let raw_descriptor = [
+            0xff, 0xff, // Type=VendorDefined
+            0x10, 0x00, // size=16
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E,
+            0x0F, 0x10,
+        ];
+        let decoded_raw_descriptor = Descriptor::decode(&raw_descriptor).unwrap();
+        assert_eq!(
+            decoded_raw_descriptor.descriptor_type,
+            DescriptorType::VendorDefined as u16,
+        );
+        assert_eq!(decoded_raw_descriptor.descriptor_length, 16,);
+        assert_eq!(
+            &decoded_raw_descriptor.descriptor_data[..16],
+            &raw_descriptor[4..20]
+        );
     }
 
     #[test]

--- a/src/protocol/firmware_update.rs
+++ b/src/protocol/firmware_update.rs
@@ -333,65 +333,6 @@ impl Descriptor {
     }
 }
 
-// impl PldmCodec for Descriptor {
-//     fn encode(&self, buffer: &mut [u8]) -> Result<usize, PldmCodecError> {
-//         if buffer.len() < self.codec_size_in_bytes() {
-//             return Err(PldmCodecError::BufferTooShort);
-//         }
-//         let mut offset = 0;
-
-//         self.descriptor_type
-//             .write_to(&mut buffer[offset..offset + core::mem::size_of::<u16>()])
-//             .unwrap();
-//         offset += core::mem::size_of::<u16>();
-
-//         self.descriptor_length
-//             .write_to(&mut buffer[offset..offset + core::mem::size_of::<u16>()])
-//             .unwrap();
-//         offset += core::mem::size_of::<u16>();
-
-//         self.descriptor_data[..self.descriptor_length as usize]
-//             .write_to(&mut buffer[offset..offset + self.descriptor_length as usize])
-//             .unwrap();
-//         offset += self.descriptor_length as usize;
-
-//         Ok(offset)
-//     }
-
-//     fn decode(buffer: &[u8]) -> Result<Self, PldmCodecError> {
-//         let mut offset = 0;
-
-//         let descriptor_type = u16::read_from_bytes(
-//             buffer
-//                 .get(offset..offset + core::mem::size_of::<u16>())
-//                 .ok_or(PldmCodecError::BufferTooShort)?,
-//         )
-//         .unwrap();
-//         offset += core::mem::size_of::<u16>();
-
-//         let descriptor_length = u16::read_from_bytes(
-//             buffer
-//                 .get(offset..offset + core::mem::size_of::<u16>())
-//                 .ok_or(PldmCodecError::BufferTooShort)?,
-//         )
-//         .unwrap();
-//         offset += core::mem::size_of::<u16>();
-
-//         let mut descriptor_data = [0u8; DESCRIPTOR_DATA_MAX_LEN];
-//         descriptor_data[..descriptor_length as usize].copy_from_slice(
-//             buffer
-//                 .get(offset..offset + descriptor_length as usize)
-//                 .ok_or(PldmCodecError::BufferTooShort)?,
-//         );
-
-//         Ok(Descriptor {
-//             descriptor_type,
-//             descriptor_length,
-//             descriptor_data,
-//         })
-//     }
-// }
-
 bitfield! {
     /// FDPCapabilitiesDuringUpdate
     ///
@@ -541,9 +482,8 @@ impl PldmCodec for PldmFirmwareString {
         self.str_data[..self.str_len as usize]
             .write_to(&mut buffer[offset..offset + self.str_len as usize])
             .unwrap();
-        offset += self.str_len as usize;
 
-        Ok(offset)
+        Ok(offset + self.str_len as usize)
     }
 
     fn decode(buffer: &[u8]) -> Result<Self, PldmCodecError> {


### PR DESCRIPTION
- [x] QueryDownstreamDevices (dc25fdfcf5f7a3beb5b64074c8878f49ac22455f)
  - [x] test_query_downstream_devices_request_codec
  - [x] test_query_downstream_devices_response_codec
- [x] QueryDownstreamIdentifiers (dc25fdfcf5f7a3beb5b64074c8878f49ac22455f)
  - [x] test_query_downstream_identifiers_request_codec
  - [x] test_query_downstream_identifiers_response_codec
- [x] GetDownstreamFirmwareParameters (b63b0f6e768495141c0ca80e3521c55dcaf1d5de)
  - [x] test_get_downstream_firmware_parameters_request_codec
  - [x] test_get_downstream_firmware_parameters_response_codec
  - [x] test_device_parameter_table_codec
  - [x] test_get_downstream_firmware_parameters_portion_codec
- [x] RequestDownstreamDeviceUpdate (69aac442a430e47461e5756bf85220badb6563ca)
  - [x] test_request_downstream_device_update_request_codec
  - [x] test_request_downstream_device_update_response_codec
- [x] GetPackageData (ab8f4588d0e2b08b4bd031c1f44cfd7ca1420f5b)
    - [x] test_get_package_data_request_codec
    - [x] test_get_package_data_response_codec
- [x] GetDeviceMetaData (1face4e2397a48e119ba783d988ff354c91d9aa2)
    - [x] test_get_device_meta_data_request_codec
    - [x] test_get_device_meta_data_response_codec
- [x] GetMetaData (116aebd16367ebbb62cfaf6bde575580ae10ad9f)
    - [x] test_get_metadata_request_codec
    - [x] test_get_meta_data_response_codec